### PR TITLE
add support for 'audienceClosedRegisteredText'

### DIFF
--- a/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/NINQuestionnaireConversationDataSourceDelegate.swift
+++ b/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/NINQuestionnaireConversationDataSourceDelegate.swift
@@ -216,7 +216,7 @@ extension NINQuestionnaireConversationDataSourceDelegate {
         return true
     }
 
-    func addClosedRegisteredSection(after interval: Double) -> Bool {
+    func addClosedRegisteredSection() -> Bool {
         guard let registerTitle = self.session.sessionManager.siteConfiguration.audienceClosedRegisteredText else { return false }
         let closeTitle = self.session.sessionManager.translate(key: Constants.kCloseChatText.rawValue, formatParams: [:]) ?? "Close Chat"
         let registerJSON: [String:AnyHashable] = ["element": "radio", "name": "audienceClosedRegisteredText", "label": registerTitle, "buttons": ["back":false,"next":false], "options":[["label":closeTitle, "value":""]], "redirects":[["target":"_register"]]]
@@ -224,14 +224,11 @@ extension NINQuestionnaireConversationDataSourceDelegate {
         guard let registerConfiguration = AudienceQuestionnaire(from: [registerJSON]).questionnaireConfiguration, registerConfiguration.count > 0, let element = QuestionnaireElementConverter(configurations: registerConfiguration).elements.first else { return false }
         element.compactMap({ $0 as? QuestionnaireElementRadio }).first?.isExitElement = true
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + interval) {
-            self.elements.append(element)
-            self.configurations.append(contentsOf: registerConfiguration)
-            self.requirementSatisfactions.append(false)
-            self.shouldShowNavigationCells.append(false)
-            self.viewModel.insertRegisteredElement(element, configuration: registerConfiguration)
-        }
-
+        self.elements.append(element)
+        self.configurations.append(contentsOf: registerConfiguration)
+        self.requirementSatisfactions.append(false)
+        self.shouldShowNavigationCells.append(false)
+        self.viewModel.insertRegisteredElement(element, configuration: registerConfiguration)
         return true
     }
 }

--- a/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/NINQuestionnaireConversationDataSourceDelegate.swift
+++ b/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/NINQuestionnaireConversationDataSourceDelegate.swift
@@ -215,4 +215,23 @@ extension NINQuestionnaireConversationDataSourceDelegate {
 
         return true
     }
+
+    func addClosedRegisteredSection(after interval: Double) -> Bool {
+        guard let registerTitle = self.session.sessionManager.siteConfiguration.audienceClosedRegisteredText else { return false }
+        let closeTitle = self.session.sessionManager.translate(key: Constants.kCloseChatText.rawValue, formatParams: [:]) ?? "Close Chat"
+        let registerJSON: [String:AnyHashable] = ["element": "radio", "name": "audienceClosedRegisteredText", "label": registerTitle, "buttons": ["back":false,"next":false], "options":[["label":closeTitle, "value":""]], "redirects":[["target":"_register"]]]
+
+        guard let registerConfiguration = AudienceQuestionnaire(from: [registerJSON]).questionnaireConfiguration, registerConfiguration.count > 0, let element = QuestionnaireElementConverter(configurations: registerConfiguration).elements.first else { return false }
+        element.compactMap({ $0 as? QuestionnaireElementRadio }).first?.isExitElement = true
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + interval) {
+            self.elements.append(element)
+            self.configurations.append(contentsOf: registerConfiguration)
+            self.requirementSatisfactions.append(false)
+            self.shouldShowNavigationCells.append(false)
+            self.viewModel.insertRegisteredElement(element, configuration: registerConfiguration)
+        }
+
+        return true
+    }
 }

--- a/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/NINQuestionnaireFormDataSourceDelegate.swift
+++ b/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/NINQuestionnaireFormDataSourceDelegate.swift
@@ -122,7 +122,7 @@ extension NINQuestionnaireFormDataSourceDelegate {
         return true
     }
 
-    func addClosedRegisteredSection(after interval: Double) -> Bool {
+    func addClosedRegisteredSection() -> Bool {
         guard let registerTitle = self.session.sessionManager.siteConfiguration.audienceClosedRegisteredText else { return false }
         let closeTitle = self.session.sessionManager.translate(key: Constants.kCloseChatText.rawValue, formatParams: [:]) ?? "Close Chat"
         let registerJSON: [String:AnyHashable] = ["element": "radio", "name": "audienceClosedRegisteredText", "label": registerTitle, "buttons": ["back":false,"next":false], "options":[["label":closeTitle, "value":""]], "redirects":[["target":"_register"]]]

--- a/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/NINQuestionnaireFormDataSourceDelegate.swift
+++ b/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/NINQuestionnaireFormDataSourceDelegate.swift
@@ -121,4 +121,16 @@ extension NINQuestionnaireFormDataSourceDelegate {
 
         return true
     }
+
+    func addClosedRegisteredSection(after interval: Double) -> Bool {
+        guard let registerTitle = self.session.sessionManager.siteConfiguration.audienceClosedRegisteredText else { return false }
+        let closeTitle = self.session.sessionManager.translate(key: Constants.kCloseChatText.rawValue, formatParams: [:]) ?? "Close Chat"
+        let registerJSON: [String:AnyHashable] = ["element": "radio", "name": "audienceClosedRegisteredText", "label": registerTitle, "buttons": ["back":false,"next":false], "options":[["label":closeTitle, "value":""]], "redirects":[["target":"_register"]]]
+
+        guard let registerConfiguration = AudienceQuestionnaire(from: [registerJSON]).questionnaireConfiguration, registerConfiguration.count > 0, let element = QuestionnaireElementConverter(configurations: registerConfiguration).elements.first else { return false }
+        element.compactMap({ $0 as? QuestionnaireElementRadio }).first?.isExitElement = true
+        self.viewModel.insertRegisteredElement(element, configuration: registerConfiguration)
+
+        return true
+    }
 }

--- a/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/QuestionnaireDataSourceDelegate.swift
+++ b/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/QuestionnaireDataSourceDelegate.swift
@@ -32,7 +32,7 @@ protocol QuestionnaireDataSource {
     func addRegisterSection()-> Bool
 
     /** Add an extra section/page to questionnaires to show 'audienceRegisteredClosedText' */
-    func addClosedRegisteredSection(after interval: Double) -> Bool
+    func addClosedRegisteredSection() -> Bool
 
     var session: NINChatSession! { get }
     var viewModel: NINQuestionnaireViewModel! { get set }

--- a/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/QuestionnaireDataSourceDelegate.swift
+++ b/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/QuestionnaireDataSourceDelegate.swift
@@ -31,6 +31,9 @@ protocol QuestionnaireDataSource {
     /** Add an extra section/page to questionnaires to show 'AudienceRegisteredText' */
     func addRegisterSection()-> Bool
 
+    /** Add an extra section/page to questionnaires to show 'audienceRegisteredClosedText' */
+    func addClosedRegisteredSection(after interval: Double) -> Bool
+
     var session: NINChatSession! { get }
     var viewModel: NINQuestionnaireViewModel! { get set }
     init(viewModel: NINQuestionnaireViewModel, session: NINChatSession)

--- a/NinchatSDKSwift/Implementations/Models/SiteConfiguration.swift
+++ b/NinchatSDKSwift/Implementations/Models/SiteConfiguration.swift
@@ -29,6 +29,7 @@ protocol SiteConfiguration  {
     var audienceQuestionnaireAvatar: AnyHashable? { get }
     var audienceQuestionnaireUserName: String? { get }
     var audienceRegisteredText: String? { get }
+    var audienceClosedRegisteredText: String? { get }
     var preAudienceQuestionnaireStyle: QuestionnaireStyle { get }
     var preAudienceQuestionnaire: [QuestionnaireConfiguration]? { get }
     var postAudienceQuestionnaireStyle: QuestionnaireStyle { get }
@@ -107,6 +108,9 @@ struct SiteConfigurationImpl: SiteConfiguration {
     }
     var audienceRegisteredText: String? {
         self.value(for: "audienceRegisteredText")
+    }
+    var audienceClosedRegisteredText: String? {
+        self.value(for: "audienceClosedRegisteredText")
     }
 
     // MARK: - PreAudience Questionnaire

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINQuestionnaireViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINQuestionnaireViewController.swift
@@ -46,8 +46,10 @@ final class NINQuestionnaireViewController: UIViewController, ViewController {
     }
     var viewModel: NINQuestionnaireViewModel! {
         didSet {
-            viewModel.onErrorOccurred = { error in
+            viewModel.onErrorOccurred = { [weak self] error in
                 debugger("** ** SDK: error in registering audience: \(error)")
+                /// Add 'audienceRegisteredClosedText' after a short delay, to ensure 'dataSourceDelegate.onUpdateCellContent' called first
+                if let error = error as? NinchatError, error.title == "queue_is_closed", self?.dataSourceDelegate.addClosedRegisteredSection(after: 0.5) ?? false { return }
                 Toast.show(message: .error("Error is submitting the answers")) { [weak self] in
                     self?.session.onDidEnd()
                 }

--- a/NinchatSDKSwiftTests/QuestionnaireDataSourceDelegateTests.swift
+++ b/NinchatSDKSwiftTests/QuestionnaireDataSourceDelegateTests.swift
@@ -191,4 +191,23 @@ extension QuestionnaireDataSourceDelegateTests {
         XCTAssertFalse((conversationQuestionnaireDataSource as! NINQuestionnaireConversationDataSourceDelegate).requirementSatisfactions.last ?? true)
         XCTAssertFalse((conversationQuestionnaireDataSource as! NINQuestionnaireConversationDataSourceDelegate).shouldShowNavigationCells.last ?? true)
     }
+
+    func test_012_audienceClosedRegisteredSection() {
+        let currentElementsCount = (conversationQuestionnaireDataSource as! NINQuestionnaireConversationDataSourceDelegate).elements.count
+        let currentConfigurationCount = (conversationQuestionnaireDataSource as! NINQuestionnaireConversationDataSourceDelegate).configurations.count
+        XCTAssertTrue(conversationQuestionnaireDataSource.addClosedRegisteredSection(after: 0.5))
+
+        let expect = self.expectation(description: "Expected to get elements and configurations updated after some delay")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            let newElementsCount = (self.conversationQuestionnaireDataSource as! NINQuestionnaireConversationDataSourceDelegate).elements.count
+            let newConfigurationCount = (self.conversationQuestionnaireDataSource as! NINQuestionnaireConversationDataSourceDelegate).configurations.count
+
+            XCTAssertEqual(newElementsCount, currentElementsCount+1)
+            XCTAssertEqual(newConfigurationCount, currentConfigurationCount+1)
+            XCTAssertFalse((self.conversationQuestionnaireDataSource as! NINQuestionnaireConversationDataSourceDelegate).requirementSatisfactions.last ?? true)
+            XCTAssertFalse((self.conversationQuestionnaireDataSource as! NINQuestionnaireConversationDataSourceDelegate).shouldShowNavigationCells.last ?? true)
+            expect.fulfill()
+        }
+        waitForExpectations(timeout: 1.5)
+    }
 }

--- a/NinchatSDKSwiftTests/QuestionnaireDataSourceDelegateTests.swift
+++ b/NinchatSDKSwiftTests/QuestionnaireDataSourceDelegateTests.swift
@@ -195,19 +195,14 @@ extension QuestionnaireDataSourceDelegateTests {
     func test_012_audienceClosedRegisteredSection() {
         let currentElementsCount = (conversationQuestionnaireDataSource as! NINQuestionnaireConversationDataSourceDelegate).elements.count
         let currentConfigurationCount = (conversationQuestionnaireDataSource as! NINQuestionnaireConversationDataSourceDelegate).configurations.count
-        XCTAssertTrue(conversationQuestionnaireDataSource.addClosedRegisteredSection(after: 0.5))
+        XCTAssertTrue(conversationQuestionnaireDataSource.addClosedRegisteredSection())
+        let newElementsCount = (self.conversationQuestionnaireDataSource as! NINQuestionnaireConversationDataSourceDelegate).elements.count
+        let newConfigurationCount = (self.conversationQuestionnaireDataSource as! NINQuestionnaireConversationDataSourceDelegate).configurations.count
 
-        let expect = self.expectation(description: "Expected to get elements and configurations updated after some delay")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            let newElementsCount = (self.conversationQuestionnaireDataSource as! NINQuestionnaireConversationDataSourceDelegate).elements.count
-            let newConfigurationCount = (self.conversationQuestionnaireDataSource as! NINQuestionnaireConversationDataSourceDelegate).configurations.count
+        XCTAssertEqual(newElementsCount, currentElementsCount+1)
+        XCTAssertEqual(newConfigurationCount, currentConfigurationCount+1)
+        XCTAssertFalse((self.conversationQuestionnaireDataSource as! NINQuestionnaireConversationDataSourceDelegate).requirementSatisfactions.last ?? true)
+        XCTAssertFalse((self.conversationQuestionnaireDataSource as! NINQuestionnaireConversationDataSourceDelegate).shouldShowNavigationCells.last ?? true)
 
-            XCTAssertEqual(newElementsCount, currentElementsCount+1)
-            XCTAssertEqual(newConfigurationCount, currentConfigurationCount+1)
-            XCTAssertFalse((self.conversationQuestionnaireDataSource as! NINQuestionnaireConversationDataSourceDelegate).requirementSatisfactions.last ?? true)
-            XCTAssertFalse((self.conversationQuestionnaireDataSource as! NINQuestionnaireConversationDataSourceDelegate).shouldShowNavigationCells.last ?? true)
-            expect.fulfill()
-        }
-        waitForExpectations(timeout: 1.5)
     }
 }

--- a/NinchatSDKSwiftTests/Resources/site-configuration-mock.json
+++ b/NinchatSDKSwiftTests/Resources/site-configuration-mock.json
@@ -46,6 +46,7 @@
       "userName": "Asiakas (öäå)",
       "welcome": "Tervetuloa keskusteluun öäå (welcome)",
       "audienceRegisteredText": "Kysely rekisteröity..",
+      "audienceClosedRegisteredText": "Jono on suljettu..",
       "preAudienceQuestionnaire": [
         {
           "element": "radio",


### PR DESCRIPTION
Currently, only supports queues that are 'open' but has 'Enable audience registration' unchecked. __Adding support for 'closed' queues require more updates that will involve scopes beyond just questionnaires__

missed from somia/mobile#217