### PR TITLE
fix issue by terminating the video call

### DIFF
--- a/NinchatSDKSwift/Implementations/View Model/NINChatViewModel.swift
+++ b/NinchatSDKSwift/Implementations/View Model/NINChatViewModel.swift
@@ -14,27 +14,27 @@ enum MessageUpdateType {
 }
 
 protocol NINChatRTCProtocol {
-    typealias RTCCallReceive = ((ChannelUser?) -> Void)
-    typealias RTCCallInitial = ((Error?, NINChatWebRTCClient?) -> Void)
-    typealias RTCCallHangup = (() -> Void)
+    typealias RTCCallReceive = (ChannelUser?) -> Void
+    typealias RTCCallInitial = (Error?, NINChatWebRTCClient?) -> Void
+    typealias RTCCallHangup = () -> Void
     
     func listenToRTCSignaling(delegate: NINChatWebRTCClientDelegate?, onCallReceived: @escaping RTCCallReceive, onCallInitiated: @escaping RTCCallInitial, onCallHangup: @escaping RTCCallHangup)
-    func pickup(answer: Bool, completion: @escaping ((Error?) -> Void))
+    func pickup(answer: Bool, completion: @escaping (Error?) -> Void)
     func disconnectRTC(_ client: NINChatWebRTCClient?, completion: (() -> Void)?)
 }
 
 protocol NINChatStateProtocol {
-    func appDidEnterBackground(completion: @escaping ((Error?) -> Void))
-    func appWillResignActive(completion: @escaping ((Error?) -> Void))
+    func appDidEnterBackground(completion: @escaping (Error?) -> Void)
+    func appWillResignActive(completion: @escaping (Error?) -> Void)
 }
 
 protocol NINChatMessageProtocol {
     func updateWriting(state: Bool)
-    func send(message: String, completion: @escaping ((Error?) -> Void))
-    func send(action: ComposeContentViewProtocol, completion: @escaping ((Error?) -> Void))
-    func send(attachment: String, data: Data, completion: @escaping ((Error?) -> Void))
-    func send(type: MessageType, payload: [String:String], completion: @escaping ((Error?) -> Void))
-    func loadHistory(completion: @escaping ((Error?) -> Void))
+    func send(message: String, completion: @escaping (Error?) -> Void)
+    func send(action: ComposeContentViewProtocol, completion: @escaping (Error?) -> Void)
+    func send(attachment: String, data: Data, completion: @escaping (Error?) -> Void)
+    func send(type: MessageType, payload: [String:String], completion: @escaping (Error?) -> Void)
+    func loadHistory(completion: @escaping (Error?) -> Void)
 }
 
 protocol NINChatViewModel: NINChatRTCProtocol, NINChatStateProtocol, NINChatMessageProtocol {
@@ -117,7 +117,7 @@ extension NINChatViewModelImpl {
         }
     }
     
-    func pickup(answer: Bool, completion: @escaping ((Error?) -> Void)) {
+    func pickup(answer: Bool, completion: @escaping (Error?) -> Void) {
         do {
             try self.sessionManager.send(type: .pickup, payload: ["answer": answer], completion: completion)
         } catch {
@@ -137,7 +137,7 @@ extension NINChatViewModelImpl {
 // MARK: - NINChatState
 
 extension NINChatViewModelImpl {
-    func appDidEnterBackground(completion: @escaping ((Error?) -> Void)) {
+    func appDidEnterBackground(completion: @escaping (Error?) -> Void) {
         do {
             try self.sessionManager.send(type: .hangup, payload: [:], completion: completion)
         } catch {
@@ -145,13 +145,13 @@ extension NINChatViewModelImpl {
         }
     }
     
-    func appWillResignActive(completion: @escaping ((Error?) -> Void)) {}
+    func appWillResignActive(completion: @escaping (Error?) -> Void) {}
 }
 
 // MARK: - NINChatMessage
 
 extension NINChatViewModelImpl {
-    func send(message: String, completion: @escaping ((Error?) -> Void)) {
+    func send(message: String, completion: @escaping (Error?) -> Void) {
         do {
             try self.sessionManager.send(message: message, completion: completion)
         } catch {
@@ -159,7 +159,7 @@ extension NINChatViewModelImpl {
         }
     }
     
-    func send(action: ComposeContentViewProtocol, completion: @escaping ((Error?) -> Void)) {
+    func send(action: ComposeContentViewProtocol, completion: @escaping (Error?) -> Void) {
         do {
             try self.sessionManager.send(action: action, completion: completion)
         } catch {
@@ -167,7 +167,7 @@ extension NINChatViewModelImpl {
         }
     }
     
-    func send(attachment: String, data: Data, completion: @escaping ((Error?) -> Void)) {
+    func send(attachment: String, data: Data, completion: @escaping (Error?) -> Void) {
         do {
             try self.sessionManager.send(attachment: attachment, data: data, completion: completion)
         } catch {
@@ -175,7 +175,7 @@ extension NINChatViewModelImpl {
         }
     }
     
-    func send(type: MessageType, payload: [String:String], completion: @escaping ((Error?) -> Void)) {
+    func send(type: MessageType, payload: [String:String], completion: @escaping (Error?) -> Void) {
         do {
             try self.sessionManager.send(type: type, payload: payload, completion: completion)
         } catch {
@@ -187,7 +187,7 @@ extension NINChatViewModelImpl {
         try? self.sessionManager.update(isWriting: state, completion: { _ in })
     }
 
-    func loadHistory(completion: @escaping ((Error?) -> Void)) {
+    func loadHistory(completion: @escaping (Error?) -> Void) {
         do {
             try self.sessionManager.loadHistory(completion: completion)
         } catch {

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINChatViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINChatViewController.swift
@@ -522,13 +522,13 @@ extension NINChatViewController {
             }
         }
     }
-    
+
     @objc
     private func willResignActive(notification: Notification) {
-        debugger("applicationWillResignActive: no action.")
-        
-        /// TODO: pause video - if one should be active - here?
-        viewModel.appWillResignActive { _ in }
+        /// For the time-being, the solo solution is to terminate the call and then re-initiate it from the agent.
+        /// I may pause/resume the video later, when I figure out how to.
+        self.didEnterBackground(notification: notification)
+//        viewModel.appWillResignActive { _ in }
     }
 }
 


### PR DESCRIPTION
For the time being, the solution is to terminate the call by sending hang-up action to the server, then, the agent must initiate a new call to continue the chat.
Later, we may find a way to pause/resume the call, or a way to initiate an unfinished one from the SDK.

closes somia/mobile#243﻿
