### PR TITLE
fix reported crash on regex patterns in redirect blocks

### DIFF
--- a/NinchatSDKSwift/Implementations/Utilities/QuestionnaireElementConnector.swift
+++ b/NinchatSDKSwift/Implementations/Utilities/QuestionnaireElementConnector.swift
@@ -76,7 +76,9 @@ extension QuestionnaireElementConnectorImpl {
     /// The input could be either the 'name' variable in QuestionnaireConfiguration object
     /// Or 'value' in ElementOption object
     internal func findAssociatedRedirect(for input: String, in configuration: QuestionnaireConfiguration) -> ElementRedirect? {
-        if let redirect = configuration.redirects?.first(where: { $0.pattern ?? "" == input }) {
+        if let redirect = configuration.redirects?.first(where: { input.extractRegex(withPattern: $0.pattern ?? "")?.count ?? 0 > 0 }) {
+            return redirect
+        } else if let redirect = configuration.redirects?.first(where: { $0.pattern ?? "" == input }) {
             return redirect
         }
         return nil

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINQuestionnaireViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINQuestionnaireViewController.swift
@@ -330,7 +330,6 @@ extension NINQuestionnaireViewController: UITableViewDataSource, UITableViewDele
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let contentView = self.contentView, let cell = self.dataSourceDelegate?.cell(at: indexPath, view: contentView) else { return UITableViewCell() }
-        return cell
+        self.dataSourceDelegate!.cell(at: indexPath, view: self.contentView!)
     }
 }

--- a/NinchatSDKSwiftTests/QuestionnaireElementConnectorRedirectTests.swift
+++ b/NinchatSDKSwiftTests/QuestionnaireElementConnectorRedirectTests.swift
@@ -56,6 +56,9 @@ final class QuestionnaireElementConnectorRedirectTests: XCTestCase {
 
         let target_2 = connector.findAssociatedRedirect(for: "", in: self.configuration!)
         XCTAssertNotNil(target_2)
+
+        let target_3 = connector.findAssociatedRedirect(for: "40", in: self.configuration!)
+        XCTAssertNotNil(target_3)
     }
 
     func test_13_find_configuration() {

--- a/NinchatSDKSwiftTests/Resources/questionnaire-mock.json
+++ b/NinchatSDKSwiftTests/Resources/questionnaire-mock.json
@@ -85,6 +85,10 @@
           "target": "Huolet"
         },
         {
+          "pattern": "[4-9]\\d+|\\d{3,}",
+          "target": "Huolet"
+        },
+        {
           "pattern": "",
           "target": "_register"
         }


### PR DESCRIPTION
fix a reported crash﻿on parsing redirect blocks that contain regex patterns
