### PR TITLE
fix an issue with rendering embedded images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ NinchatSDKSwiftServerTests/Secrets.plist
 
 *.out
 *.log
+
+go-sdk/

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementText.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementText.swift
@@ -11,6 +11,9 @@ final class QuestionnaireElementText: UITextView, QuestionnaireElement {
     fileprivate var conversationStylePadding: CGFloat {
         (self.questionnaireStyle == .conversation) ? 75 : 0
     }
+    private var estimatedWidth: CGFloat {
+        (UIApplication.topViewController()?.view.bounds ?? UIScreen.main.bounds).width - conversationStylePadding
+    }
 
     // MARK: - QuestionnaireElement
 
@@ -32,12 +35,12 @@ final class QuestionnaireElementText: UITextView, QuestionnaireElement {
     }
     var elementConfiguration: QuestionnaireConfiguration?
     var elementHeight: CGFloat {
-        self.estimateHeight(width: (UIApplication.topViewController()?.view.bounds ?? UIScreen.main.bounds).width - conversationStylePadding)
+        self.estimateHeight(width: self.estimatedWidth)
     }
 
     func overrideAssets(with delegate: NINChatSessionInternalDelegate?) {
         if let overriddenColor = delegate?.override(questionnaireAsset: .titleTextColor) {
-            self.setAttributed(text: self.elementConfiguration?.label ?? "", font: .ninchat, color: overriddenColor)
+            self.setAttributed(text: self.elementConfiguration?.label ?? "", font: .ninchat, color: overriddenColor, width:  self.estimatedWidth - 24.0)
         }
     }
 
@@ -74,9 +77,7 @@ extension QuestionnaireElement where Self:QuestionnaireElementText {
     func shapeView(_ configuration: QuestionnaireConfiguration?) {
         self.textAlignment = .left
         self.backgroundColor = .clear
-        self.setAttributed(text: configuration?.label ?? "", font: .ninchat, width: UIScreen.main.bounds.width - conversationStylePadding - 24.0)
+        self.setAttributed(text: configuration?.label ?? "", font: .ninchat, width: UIScreen.main.bounds.width - self.conversationStylePadding - 21.0)
         self.elementConfiguration = configuration
-
-        self.layoutIfNeeded()
     }
 }

--- a/NinchatSDKSwiftTests/ExtensionsTests.swift
+++ b/NinchatSDKSwiftTests/ExtensionsTests.swift
@@ -48,17 +48,17 @@ final class ExtensionsTests: XCTestCase {
 
     func test_html_string_utf16() {
         let expect_url = self.expectation(description: "Expected to get back the url from attributed string")
-        expect_url.expectedFulfillmentCount = 2
+        expect_url.assertForOverFulfill = false
 
         let expect_style = self.expectation(description: "Expected to get appropriate style from attributed string")
-        expect_style.expectedFulfillmentCount = 2
+        expect_style.assertForOverFulfill = false
 
         func test_link1() {
             let url = "https://www.ninchat.com/"
             let text = "<a href=\"https://www.ninchat.com\">salaries_by_field_of_study_2018.pdf</a>"
             let attrString = text.htmlAttributedString(withFont: .ninchat, alignment: .left, color: .black, width: nil)
             XCTAssertNotNil(attrString)
-            XCTAssertEqual(attrString?.string, "salaries_by_field_of_study_2018.pdf")
+            XCTAssertEqual(attrString?.string, "salaries_by_field_of_study_2018.pdf\n")
 
             attrString!.enumerateAttributes(in: NSMakeRange(0, attrString!.length)) { attributes, range, stopped in
                 attributes.forEach { key, value in
@@ -81,7 +81,7 @@ final class ExtensionsTests: XCTestCase {
             let text = "<a href=\"https://www.ninchat.com\">Pellon kuivatusjärjestelmät ja ravinteiden talteenotto raportti.pdf</a>"
             let attrString = text.htmlAttributedString(withFont: .ninchat, alignment: .left, color: .black, width: nil)
             XCTAssertNotNil(attrString)
-            XCTAssertEqual(attrString?.string, "Pellon kuivatusjärjestelmät ja ravinteiden talteenotto raportti.pdf")
+            XCTAssertEqual(attrString?.string, "Pellon kuivatusjärjestelmät ja ravinteiden talteenotto raportti.pdf\n")
 
             attrString!.enumerateAttributes(in: NSMakeRange(0, attrString!.length)) { attributes, range, stopped in
                 attributes.forEach { key, value in


### PR DESCRIPTION
The issue was made mainly because of incomplete font override by iOS. By injecting the font into the HTML using an inline CSS, the issue is solved.
