### PR TITLE
bump to version 0.3.6

### DIFF
--- a/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/NINQuestionnaireConversationDataSourceDelegate.swift
+++ b/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/NINQuestionnaireConversationDataSourceDelegate.swift
@@ -158,11 +158,11 @@ extension NINQuestionnaireConversationDataSourceDelegate {
         cell.shouldShowNextButton = self.configurations[indexPath.section].buttons?.hasValidNextButton ?? true
         cell.shouldShowBackButton = (self.configurations[indexPath.section].buttons?.hasValidBackButton ?? true) && indexPath.section != 0
         cell.configuration = self.configurations[indexPath.section]
-        cell.requirementsSatisfied = self.requirementsSatisfied
-        cell.disabled = indexPath.section != sectionCount-1
         cell.backgroundColor = .clear
         cell.isUserInteractionEnabled = (self.elements[indexPath.section].first?.isShown ?? true) && (indexPath.section == self.sectionCount-1)
         cell.overrideAssets(with: self.session?.internalDelegate)
+        // Need to check only for the last item if to enable/disable navigation buttons
+        cell.setSatisfaction(self.requirementsSatisfied && indexPath.section == sectionCount-1, lastItem: indexPath.section == sectionCount-1)
 
         cell.onNextButtonTapped = { [weak self] in
             self?.onNextButtonTapped(elements: self?.elements[indexPath.section])

--- a/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/NINQuestionnaireConversationDataSourceDelegate.swift
+++ b/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/NINQuestionnaireConversationDataSourceDelegate.swift
@@ -84,7 +84,6 @@ final class NINQuestionnaireConversationDataSourceDelegate: QuestionnaireDataSou
             self.configurations.append(try self.viewModel.getConfiguration())
             self.shouldShowNavigationCells.append(self.shouldShowNavigationCell(at: index.section))
             self.enableCurrentRows()
-            self.clearCurrentRows()
 
             return (index.row == (try self.viewModel.getElements().count)) ? self.navigation(view, cellForRowAt: index) : self.questionnaire(view, cellForRowAt: index)
         } catch {
@@ -109,7 +108,7 @@ extension NINQuestionnaireConversationDataSourceDelegate: QuestionnaireConversat
     func removeSection() -> Int {
         defer { self.disablePreviousRows(false) }
 
-        self.clearCurrentRows()
+        self.clearCurrentAndPreviousRows()
         sectionCount -= 1
         rowCount.remove(at: sectionCount)
         if elements.count > sectionCount { elements.remove(at: sectionCount) }
@@ -127,9 +126,19 @@ extension NINQuestionnaireConversationDataSourceDelegate: QuestionnaireConversat
         self.elements[sectionCount-1].forEach({ $0.isShown = true;  $0.alpha = 1.0 })
     }
 
-    private func clearCurrentRows() {
-        guard self.elements.count > self.sectionCount else { return }
-        self.elements[sectionCount-1].compactMap({ $0 as? QuestionnaireOptionSelectableElement }).forEach({ $0.deselectAll() })
+    private func clearCurrentAndPreviousRows() {
+        if self.elements.count > self.sectionCount - 1 {
+            self.elements[sectionCount-1].forEach({
+                ($0 as? QuestionnaireOptionSelectableElement)?.deselectAll()
+                ($0 as? QuestionnaireFocusableElement)?.clearAll()
+            })
+        }
+        if self.elements.count > self.sectionCount - 2 {
+            self.elements[sectionCount-2].forEach({
+                ($0 as? QuestionnaireOptionSelectableElement)?.deselectAll()
+                ($0 as? QuestionnaireFocusableElement)?.clearAll()
+            })
+        }
     }
 }
 

--- a/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/NINQuestionnaireFormDataSourceDelegate.swift
+++ b/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/NINQuestionnaireFormDataSourceDelegate.swift
@@ -66,8 +66,8 @@ extension NINQuestionnaireFormDataSourceDelegate {
             cell.shouldShowNextButton = configuration.buttons?.hasValidNextButton ?? true
             cell.shouldShowBackButton = (configuration.buttons?.hasValidBackButton ?? true) && self.viewModel.pageNumber != 0
             cell.configuration = configuration
-            cell.requirementsSatisfied = self.viewModel.requirementsSatisfied
             cell.overrideAssets(with: self.session?.internalDelegate)
+            cell.setSatisfaction(self.viewModel.requirementsSatisfied, lastItem: true)
 
             cell.onNextButtonTapped = { [weak self] in
                 do {

--- a/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/QuestionnaireDataSourceDelegate.swift
+++ b/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/QuestionnaireDataSourceDelegate.swift
@@ -111,7 +111,7 @@ extension QuestionnaireDataSourceDelegate {
 extension QuestionnaireDataSourceDelegate {
     internal func setupSettable(view: inout QuestionnaireSettable, element: QuestionnaireElement) {
         let setAnswerState: QuestionnaireSettableState = self.viewModel.resetAnswer(for: element) ? .set : .nothing
-        view.updateSetAnswers(self.viewModel.getAnswersForElement(element), state: setAnswerState)
+        view.updateSetAnswers(self.viewModel.getAnswersForElement(element, presetOnly: false), state: setAnswerState)
     }
 
     internal func setupSelectable(view: inout QuestionnaireOptionSelectableElement, element: QuestionnaireElement) {

--- a/NinchatSDKSwift/Implementations/Models/SiteConfiguration.swift
+++ b/NinchatSDKSwift/Implementations/Models/SiteConfiguration.swift
@@ -153,12 +153,12 @@ extension SiteConfigurationImpl {
         debugger("Loading keys from environments: \(self.environments)")
         guard let configuration = configuration as? [String:Any] else { return nil }
 
-        /// Use given environments first, if any. Start the lookup from the end of array
-        if let value = self.environments.reversed().compactMap({ (configuration[$0] as? [String:Any])?[key] }).first as? T {
-            return value
+        /// Insert "default" to beginning of given environments and start the lookup from the end of array
+        for env in [["default"], self.environments].joined().filter({ configuration[$0] != nil }).reversed() {
+            if let value = (configuration[env] as? [String:Any])?[key] as? T { return value }
         }
 
-        /// Return value from default environment
-        return (configuration["default"] as? [String : Any])?[key] as? T
+        /// No value was found for given key in "default" + environments
+        return nil
     }
 }

--- a/NinchatSDKSwift/Implementations/View Model/NINQuestionnaireViewModel.swift
+++ b/NinchatSDKSwift/Implementations/View Model/NINQuestionnaireViewModel.swift
@@ -48,7 +48,7 @@ extension NINQuestionnaireViewModel {
     }
 
     func getAnswersForElement(_ element: QuestionnaireElement) -> AnyHashable? {
-        self.getAnswersForElement(element, presetOnly: false)
+        self.getAnswersForElement(element, presetOnly: true)
     }
 }
 
@@ -60,8 +60,8 @@ final class NINQuestionnaireViewModelImpl: NINQuestionnaireViewModel {
     private var configurations: [QuestionnaireConfiguration] = []
     internal var connector: QuestionnaireElementConnector!
     private var views: [[QuestionnaireElement]] = []
-    internal var answers: [String:AnyHashable]! = [:]
-    internal var preAnswers: [String:AnyHashable]! = [:]
+    internal var answers: [String:AnyHashable]! = [:]    // Contains answers saved by the user in the runtime
+    internal var preAnswers: [String:AnyHashable]! = [:] // Contains answers already given by the server
     private var setPageNumber: Int?
     private var setupConnectorOperation: BlockOperation!
     
@@ -299,17 +299,16 @@ extension NINQuestionnaireViewModelImpl {
 
     func getAnswersForElement(_ element: QuestionnaireElement, presetOnly: Bool = false) -> AnyHashable? {
         guard let configuration = element.elementConfiguration else { return nil }
-        if let value = self.answers[configuration.name], !presetOnly {
-            return value
-        }
         if let value = self.preAnswers[configuration.name] {
+            return value
+        } else if !presetOnly, let value = self.answers[configuration.name] {
             return value
         }
         return nil
     }
 
     func resetAnswer(for element: QuestionnaireElement) -> Bool {
-        guard let value = self.getAnswersForElement(element, presetOnly: true) as? String, self.requirementsSatisfied, element.isUserInteractionEnabled else {
+        guard let value = self.getAnswersForElement(element, presetOnly: false) as? String, self.requirementsSatisfied, element.isUserInteractionEnabled else {
             self.askedPageNumber = nil; return false
         }
 

--- a/NinchatSDKSwift/Implementations/View Model/NINQuestionnaireViewModel.swift
+++ b/NinchatSDKSwift/Implementations/View Model/NINQuestionnaireViewModel.swift
@@ -46,7 +46,6 @@ extension NINQuestionnaireViewModel {
     func logicTargetPage(for dictionary: [String:String], autoApply: Bool = true, performClosures: Bool = true) -> Int? {
         self.logicTargetPage(for: dictionary, autoApply: autoApply, performClosures: performClosures)
     }
-
     func getAnswersForElement(_ element: QuestionnaireElement) -> AnyHashable? {
         self.getAnswersForElement(element, presetOnly: true)
     }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Cells/QuestionnaireNavigationCell.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Cells/QuestionnaireNavigationCell.swift
@@ -20,16 +20,6 @@ final class QuestionnaireNavigationCell: UITableViewCell, QuestionnaireNavigatio
             self.decorateView()
         }
     }
-    var requirementsSatisfied: Bool = false {
-        didSet {
-            self.setSatisfaction(requirementsSatisfied)
-        }
-    }
-    var disabled: Bool = false {
-        didSet {
-            self.setDisableNavigations(disabled)
-        }
-    }
 
     var requirementSatisfactionUpdater: ((Bool) -> Void)?
     var onNextButtonTapped: (() -> Void)?
@@ -65,6 +55,16 @@ final class QuestionnaireNavigationCell: UITableViewCell, QuestionnaireNavigatio
             }
             backButton.layer.borderColor = delegate?.override(questionnaireAsset: .navigationBackText)?.cgColor ?? UIColor.QBlueButtonNormal.cgColor
             backButton.backgroundColor = delegate?.override(questionnaireAsset: .navigationBackBackground) ?? .white
+        }
+    }
+
+    func setSatisfaction(_ satisfied: Bool, lastItem: Bool) {
+        self.buttons.arrangedSubviews.compactMap({ $0 as? Button }).first(where: { $0.type == .next })?.isEnabled = satisfied
+        self.buttons.arrangedSubviews.compactMap({ $0 as? Button }).first(where: { $0.type == .next })?.alpha = (satisfied) ? 1.0 : 0.5
+
+        if !lastItem {
+            self.buttons.arrangedSubviews.compactMap({ $0 as? Button }).first(where: { $0.type == .back })?.isEnabled = satisfied
+            self.buttons.arrangedSubviews.compactMap({ $0 as? Button }).first(where: { $0.type == .back })?.alpha = (satisfied) ? 1.0 : 0.5
         }
     }
 
@@ -108,12 +108,9 @@ final class QuestionnaireNavigationCell: UITableViewCell, QuestionnaireNavigatio
     }
 
     private func setSatisfaction(_ satisfied: Bool) {
+        debugger("Set navigation Satisfaction: \(satisfied)")
         self.buttons.arrangedSubviews.compactMap({ $0 as? Button }).first(where: { $0.type == .next })?.isEnabled = satisfied
         self.buttons.arrangedSubviews.compactMap({ $0 as? Button }).first(where: { $0.type == .next })?.alpha = (satisfied) ? 1.0 : 0.5
-    }
-
-    private func setDisableNavigations(_ disable: Bool) {
-        self.buttons.subviews.compactMap({ $0 as? Button }).forEach({ $0.isEnabled = !disable; $0.alpha = (disable) ? 0.5 : 1.0 })
     }
 }
 
@@ -133,8 +130,6 @@ extension QuestionnaireNavigationCell {
     }
 
     func shapeNavigationButtons(_ configuration: QuestionnaireConfiguration?) {
-        self.buttons.arrangedSubviews.compactMap({ $0 as? Button }).forEach({ $0.removeFromSuperview() })
-
         func drawBackButton(isVisible: Bool) {
             if self.buttons.arrangedSubviews.compactMap({ $0 as? Button }).filter({ $0.type == .back }).count > 0 || !isVisible { return }
 
@@ -163,7 +158,6 @@ extension QuestionnaireNavigationCell {
         /// According to `https://github.com/somia/mobile/issues/238`
         /// " Basically you have buttons always displayed unless they are removed in config. "
         /// " But it should omit 'back' for the first element "
-
         drawBackButton(isVisible: self.shouldShowBackButton)
         addSeparator(isVisible: self.shouldShowNextButton || self.shouldShowBackButton)
         drawNextButton(isVisible: self.shouldShowNextButton)

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementCheckbox.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementCheckbox.swift
@@ -50,14 +50,8 @@ final class QuestionnaireElementCheckbox: UIView, QuestionnaireElementWithTitle,
     // MARK: - QuestionnaireSettable
 
     func updateSetAnswers(_ answer: AnyHashable?, state: QuestionnaireSettableState) {
-        guard let answer = answer as? String, let option = self.elementConfiguration?.options?.first(where: { $0.value == answer }) else { return }
-
-        switch state {
-        case .set:
-            self.select(option: option)
-        case .nothing:
-            break
-        }
+        guard let option = self.elementConfiguration?.options?.first(where: { $0.value == answer as? String }) else { return }
+        self.select(option: option)
     }
 
     // MARK: - QuestionnaireOptionSelectableElement

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementRadio.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementRadio.swift
@@ -51,7 +51,7 @@ class QuestionnaireElementRadio: UIView, QuestionnaireElementWithTitle, Question
         case .set:
             button.closure?(button)
         case .nothing:
-            break
+            debugger("Do nothing for Radio element")
         }
     }
 

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementSelect.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementSelect.swift
@@ -35,7 +35,7 @@ final class QuestionnaireElementSelect: UIView, QuestionnaireElementWithTitle, Q
     }
     var elementConfiguration: QuestionnaireConfiguration?
     var elementHeight: CGFloat {
-        self.title.frame.origin.y + self.title.intrinsicContentSize.height + self.heightValue + 8.0 + self.padding
+        self.title.frame.origin.y + self.title.intrinsicContentSize.height + self.heightValue + self.padding
     }
 
     func overrideAssets(with delegate: NINChatSessionInternalDelegate?) {

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementSelect.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementSelect.swift
@@ -50,14 +50,8 @@ final class QuestionnaireElementSelect: UIView, QuestionnaireElementWithTitle, Q
     // MARK: - QuestionnaireSettable
 
     func updateSetAnswers(_ answer: AnyHashable?, state: QuestionnaireSettableState) {
-        guard let answer = answer as? String, let option = self.elementConfiguration?.options?.first(where: { $0.value == answer }) else { return }
-
-        switch state {
-        case .set:
-            self.select(option: option)
-        case .nothing:
-            break
-        }
+        guard let option = self.elementConfiguration?.options?.first(where: { $0.value == answer as? String }) else { return }
+        self.select(option: option, state: state)
         self.updateBorder()
     }
 
@@ -154,17 +148,24 @@ extension QuestionnaireElementSelect {
                 self?.deselect(option: option)
             case .select(let index):
                 guard let option = self?.elementConfiguration?.options?[index] else { fatalError("Unable to pick selected option") }
-                self?.select(option: option)
+                self?.select(option: option, state: .set)
             }
             self?.updateBorder()
         }
     }
 
-    private func select(option: ElementOption) {
+    private func select(option: ElementOption, state: QuestionnaireSettableState) {
         self.selectedOption.isHighlighted = true
         self.selectedOption.text = option.label
         self.view.backgroundColor = selectedBackgroundColor
-        self.onElementOptionSelected?(option)
+
+        switch state {
+        case .set:
+            self.onElementOptionSelected?(option)
+        case .nothing:
+            debugger("Do nothing for Select element")
+        }
+
     }
 
     func deselect(option: ElementOption) {

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextArea.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextArea.swift
@@ -43,13 +43,15 @@ final class QuestionnaireElementTextArea: UIView, QuestionnaireElementWithTitle,
 
     func updateSetAnswers(_ answer: AnyHashable?, state: QuestionnaireSettableState) {
         guard let answer = answer as? String else { return }
+        self.view.text = answer
+
         switch state {
         case .set:
-            self.view.text = answer
+            self.textViewDidEndEditing(self.view)
         case .nothing:
-            break
+            debugger("Do nothing for TextArea element")
         }
-        self.textViewDidEndEditing(self.view)
+
     }
 
     // MARK: - QuestionnaireHasBorder

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextArea.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextArea.swift
@@ -9,6 +9,7 @@ import UIKit
 final class QuestionnaireElementTextArea: UIView, QuestionnaireElementWithTitle, QuestionnaireSettable, QuestionnaireHasBorder, QuestionnaireFocusableElement {
 
     fileprivate var heightValue: CGFloat = 98.0
+    private var answerUpdateWorker: DispatchWorkItem?
 
     // MARK: - QuestionnaireElement
 
@@ -126,6 +127,12 @@ extension QuestionnaireElementTextArea: UITextViewDelegate {
     }
 
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        self.answerUpdateWorker?.cancel()
+        self.answerUpdateWorker = DispatchWorkItem { [weak self] in
+            guard let weakSelf = self else { return }
+            weakSelf.onElementDismissed?(weakSelf)
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: self.answerUpdateWorker!)
         self.isCompleted = isCompleted(text: (textView.text ?? "") + text)
         return true
     }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextArea.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextArea.swift
@@ -31,7 +31,7 @@ final class QuestionnaireElementTextArea: UIView, QuestionnaireElementWithTitle,
     }
     var elementConfiguration: QuestionnaireConfiguration?
     var elementHeight: CGFloat {
-        self.title.frame.origin.y + self.title.intrinsicContentSize.height + self.heightValue + 8.0 + self.padding
+        self.title.frame.origin.y + self.title.intrinsicContentSize.height + self.heightValue + self.padding
     }
 
     func overrideAssets(with delegate: NINChatSessionInternalDelegate?) {

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextField.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextField.swift
@@ -31,7 +31,7 @@ final class QuestionnaireElementTextField: UIView, QuestionnaireElementWithTitle
     }
     var elementConfiguration: QuestionnaireConfiguration?
     var elementHeight: CGFloat {
-        self.title.frame.origin.y + self.title.intrinsicContentSize.height + self.heightValue + 4.0 + self.padding
+        self.title.frame.origin.y + self.title.intrinsicContentSize.height + self.heightValue + self.padding
     }
 
     func overrideAssets(with delegate: NINChatSessionInternalDelegate?) {

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextField.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextField.swift
@@ -9,6 +9,7 @@ import UIKit
 final class QuestionnaireElementTextField: UIView, QuestionnaireElementWithTitle, QuestionnaireSettable, QuestionnaireHasBorder, QuestionnaireFocusableElement {
 
     fileprivate var heightValue: CGFloat = 45.0
+    private var answerUpdateWorker: DispatchWorkItem?
 
     // MARK: - QuestionnaireElement
 
@@ -125,6 +126,12 @@ extension QuestionnaireElementTextField: UITextFieldDelegate {
     }
 
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        self.answerUpdateWorker?.cancel()
+        self.answerUpdateWorker = DispatchWorkItem { [weak self] in
+            guard let weakSelf = self else { return }
+            weakSelf.onElementDismissed?(weakSelf)
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: self.answerUpdateWorker!)
         self.isCompleted = isCompleted(text: (textField.text ?? "") + string)
         return true
     }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextField.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextField.swift
@@ -43,13 +43,14 @@ final class QuestionnaireElementTextField: UIView, QuestionnaireElementWithTitle
 
     func updateSetAnswers(_ answer: AnyHashable?, state: QuestionnaireSettableState) {
         guard let answer = answer as? String else { return }
+        self.view.text = answer
+
         switch state {
         case .set:
-            self.view.text = answer
+            self.textFieldDidEndEditing(self.view)
         case .nothing:
-            break
+            debugger("Do nothing for TextField element")
         }
-        self.textFieldDidEndEditing(self.view)
     }
 
     // MARK: - QuestionnaireHasBorder

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/QuestionnaireElement.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/QuestionnaireElement.swift
@@ -116,7 +116,20 @@ extension QuestionnaireElementWithTitle {
 protocol QuestionnaireFocusableElement {
     var onElementFocused: ((QuestionnaireElement) -> Void)? { get set }
     var onElementDismissed: ((QuestionnaireElement) -> Void)? { get set }
+
+    func clearAll()
 }
+extension QuestionnaireFocusableElement where Self:QuestionnaireElementTextArea {
+    func clearAll() {
+        self.view.text = ""
+    }
+}
+extension QuestionnaireFocusableElement where Self:QuestionnaireElementTextField {
+    func clearAll() {
+        self.view.text = ""
+    }
+}
+
 
 /// Add select/deselect closure for applicable elements (e.g. radio, checkbox)
 protocol QuestionnaireOptionSelectableElement {

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/QuestionnaireElement.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/QuestionnaireElement.swift
@@ -49,8 +49,8 @@ extension QuestionnaireElementWithTitle {
     }
 
     var padding: CGFloat {
-        guard let title = self.title.text else { return 8.0 }
-        return (self.questionnaireStyle == .form || title.isEmpty) ? 8.0 : 20.0
+        guard let title = self.title.text, !title.isEmpty else { return 8.0 }
+        return self.questionnaireStyle == .form ? 32.0 : 40.0
     }
 
     func addElementViews() {

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ These issues are caused by limitations of the [gomobile bind tool](https://godoc
 
 ## Overriding Image Assets
 
-Using the API delegate method `overrideImageAsset(session:forKey:)` you may supply your own Image assets as `UIImage` objects. See the table below for explanations on the supported asset keys.
+Using the API delegate method `ninchat(session:overrideImageAssetForKey)` you may supply your own Image assets as `UIImage` objects. See the table below for explanations on the supported asset keys.
 
 Note that all the buttons may not be available in the UI.
 
@@ -244,7 +244,7 @@ All the assets should be transparent where there is no color.
 
 ## Overriding Color Assets
 
-Using the API delegate method `overrideColorAsset(session:forKey:)` you may supply your own color assets as `UIColor` objects. See the table below for explanations on the supported asset keys.
+Using the API delegate method `ninchat(session:overrideColorAssetForKey)` you may supply your own color assets as `UIColor` objects. See the table below for explanations on the supported asset keys.
 
 | Asset key       | Related UI control(s)
 |:------------- |:-------------|
@@ -270,9 +270,17 @@ Using the API delegate method `overrideColorAsset(session:forKey:)` you may supp
 | .ratingNeutralText | Text of the neutral rating button
 | .ratingNegativeText | Text of the negative rating button
 
-## Overriding Questionnaire Color Assets
+## Questionnaire
+Starting version [0.3.0](https://github.com/somia/ninchat-sdk-ios-swift/releases/tag/0.3.0), the SDK adds support for configurable questionnaire that are shown before the chat starts and after the chat is finished. Using the following APIs, you can customize how questionnaire looks.
 
-Starting version [0.3.0](https://github.com/somia/ninchat-sdk-ios-swift/releases/tag/0.3.0) supports questionnaire feature before the chat starts and after the chat is finished. Using the API delegate method `ninchat(session:overrideQuestionnaireColorAssetKey)` you may supply your own color assets as `UIColor` objects. See the table below for explanations on the supported asset keys.
+### Overriding Questionnaire Image Assets
+To override questionnaire image assets, you can use the same API as other image assets, i.e. `ninchat(session:overrideImageAssetForKey)` with the following keys:
+| Asset key       | Related UI control(s)           | Notes  |
+|:------------- |:-------------|:-----|
+| .questionnaireBackground | Questionnaire view's repeating texture. | Should be repeatable (tiling). |
+
+### Overriding Questionnaire Color Assets
+Using the API delegate method `ninchat(session:overrideQuestionnaireColorAssetKey)` you may supply your own color assets as `UIColor` objects. See the table below for explanations on the supported asset keys.
 
 | Asset key                    | Related UI control(s)                                        |
 |:---------------------------- |:------------------------------------------------------------ |


### PR DESCRIPTION
- readme: update to include questionnaire image override (#155)
- questionnaire: fix view reset caused by scrolling (#161)
- questionnaire: reset row view on back button tap (#160)
- questionnaire: fix issue with enabled invalid navigation buttons (#159)
- site_config: resolve an issue for overriding null values (#158)
- questionnaire: add more padding for elements' title (#157)
- questionnaire: save answer while user typing with 0.5s delay (#156)
