### PR TITLE
bump to version 0.3.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
-
 *.lock
 Pods/
 NinchatSDKSwift.xcodeproj/xcuserdata/
 NinchatSDKSwift.xcworkspace/xcuserdata/
 NinchatSDKSwiftServerTests/Secrets.plist
+._*
 .idea/
 .run/
 

--- a/NinchatSDKSwift.xcodeproj/xcshareddata/xcschemes/NinchatSDKSwiftServerSessionTests.xcscheme
+++ b/NinchatSDKSwift.xcodeproj/xcshareddata/xcschemes/NinchatSDKSwiftServerSessionTests.xcscheme
@@ -1,10 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   version = "1.3">
-   <BuildAction>
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
-            buildForTesting = "YES">
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "85B72A9223F57ADF00D1C4BC"
@@ -16,9 +22,13 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug">
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "NO">
       <Testables>
-         <TestableReference>
+         <TestableReference
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "85B72A9223F57ADF00D1C4BC"
@@ -35,11 +45,32 @@
       </Testables>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
       useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <LocationScenarioReference
          identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
          referenceType = "1">
       </LocationScenarioReference>
    </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
 </Scheme>

--- a/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/NINQuestionnaireConversationDataSourceDelegate.swift
+++ b/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/NINQuestionnaireConversationDataSourceDelegate.swift
@@ -158,11 +158,11 @@ extension NINQuestionnaireConversationDataSourceDelegate {
         cell.shouldShowNextButton = self.configurations[indexPath.section].buttons?.hasValidNextButton ?? true
         cell.shouldShowBackButton = (self.configurations[indexPath.section].buttons?.hasValidBackButton ?? true) && indexPath.section != 0
         cell.configuration = self.configurations[indexPath.section]
-        cell.requirementsSatisfied = self.requirementsSatisfied
-        cell.disabled = indexPath.section != sectionCount-1
         cell.backgroundColor = .clear
         cell.isUserInteractionEnabled = (self.elements[indexPath.section].first?.isShown ?? true) && (indexPath.section == self.sectionCount-1)
         cell.overrideAssets(with: self.session?.internalDelegate)
+        // Need to check only for the last item if to enable/disable navigation buttons
+        cell.setSatisfaction(self.requirementsSatisfied && indexPath.section == sectionCount-1, lastItem: indexPath.section == sectionCount-1)
 
         cell.onNextButtonTapped = { [weak self] in
             self?.onNextButtonTapped(elements: self?.elements[indexPath.section])

--- a/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/NINQuestionnaireConversationDataSourceDelegate.swift
+++ b/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/NINQuestionnaireConversationDataSourceDelegate.swift
@@ -146,7 +146,7 @@ extension NINQuestionnaireConversationDataSourceDelegate: QuestionnaireConversat
 extension NINQuestionnaireConversationDataSourceDelegate {
     private func loading(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell: ChatTypingCell = tableView.dequeueReusableCell(forIndexPath: indexPath)
-        cell.populateLoading(name: self.sessionManager?.siteConfiguration.audienceQuestionnaireUserName ?? "",
+        cell.populateLoading(agentAvatarConfig: AvatarConfig(avatar: self.sessionManager?.siteConfiguration.audienceQuestionnaireAvatar, name: self.sessionManager?.siteConfiguration.audienceQuestionnaireUserName ?? ""),
                 imageAssets: self.session?.internalDelegate?.imageAssetsDictionary ?? [:],
                 colorAssets: self.session?.internalDelegate?.colorAssetsDictionary ?? [:])
 

--- a/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/NINQuestionnaireConversationDataSourceDelegate.swift
+++ b/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/NINQuestionnaireConversationDataSourceDelegate.swift
@@ -84,7 +84,6 @@ final class NINQuestionnaireConversationDataSourceDelegate: QuestionnaireDataSou
             self.configurations.append(try self.viewModel.getConfiguration())
             self.shouldShowNavigationCells.append(self.shouldShowNavigationCell(at: index.section))
             self.enableCurrentRows()
-            self.clearCurrentRows()
 
             return (index.row == (try self.viewModel.getElements().count)) ? self.navigation(view, cellForRowAt: index) : self.questionnaire(view, cellForRowAt: index)
         } catch {
@@ -109,7 +108,7 @@ extension NINQuestionnaireConversationDataSourceDelegate: QuestionnaireConversat
     func removeSection() -> Int {
         defer { self.disablePreviousRows(false) }
 
-        self.clearCurrentRows()
+        self.clearCurrentAndPreviousRows()
         sectionCount -= 1
         rowCount.remove(at: sectionCount)
         if elements.count > sectionCount { elements.remove(at: sectionCount) }
@@ -127,9 +126,19 @@ extension NINQuestionnaireConversationDataSourceDelegate: QuestionnaireConversat
         self.elements[sectionCount-1].forEach({ $0.isShown = true;  $0.alpha = 1.0 })
     }
 
-    private func clearCurrentRows() {
-        guard self.elements.count > self.sectionCount else { return }
-        self.elements[sectionCount-1].compactMap({ $0 as? QuestionnaireOptionSelectableElement }).forEach({ $0.deselectAll() })
+    private func clearCurrentAndPreviousRows() {
+        if self.elements.count > self.sectionCount - 1 {
+            self.elements[sectionCount-1].forEach({
+                ($0 as? QuestionnaireOptionSelectableElement)?.deselectAll()
+                ($0 as? QuestionnaireFocusableElement)?.clearAll()
+            })
+        }
+        if self.elements.count > self.sectionCount - 2 {
+            self.elements[sectionCount-2].forEach({
+                ($0 as? QuestionnaireOptionSelectableElement)?.deselectAll()
+                ($0 as? QuestionnaireFocusableElement)?.clearAll()
+            })
+        }
     }
 }
 

--- a/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/NINQuestionnaireFormDataSourceDelegate.swift
+++ b/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/NINQuestionnaireFormDataSourceDelegate.swift
@@ -66,8 +66,8 @@ extension NINQuestionnaireFormDataSourceDelegate {
             cell.shouldShowNextButton = configuration.buttons?.hasValidNextButton ?? true
             cell.shouldShowBackButton = (configuration.buttons?.hasValidBackButton ?? true) && self.viewModel.pageNumber != 0
             cell.configuration = configuration
-            cell.requirementsSatisfied = self.viewModel.requirementsSatisfied
             cell.overrideAssets(with: self.session?.internalDelegate)
+            cell.setSatisfaction(self.viewModel.requirementsSatisfied, lastItem: true)
 
             cell.onNextButtonTapped = { [weak self] in
                 do {

--- a/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/QuestionnaireDataSourceDelegate.swift
+++ b/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/QuestionnaireDataSourceDelegate.swift
@@ -111,7 +111,7 @@ extension QuestionnaireDataSourceDelegate {
 extension QuestionnaireDataSourceDelegate {
     internal func setupSettable(view: inout QuestionnaireSettable, element: QuestionnaireElement) {
         let setAnswerState: QuestionnaireSettableState = self.viewModel.resetAnswer(for: element) ? .set : .nothing
-        view.updateSetAnswers(self.viewModel.getAnswersForElement(element), state: setAnswerState)
+        view.updateSetAnswers(self.viewModel.getAnswersForElement(element, presetOnly: false), state: setAnswerState)
     }
 
     internal func setupSelectable(view: inout QuestionnaireOptionSelectableElement, element: QuestionnaireElement) {

--- a/NinchatSDKSwift/Implementations/Extensions/UIApplication+Extension.swift
+++ b/NinchatSDKSwift/Implementations/Extensions/UIApplication+Extension.swift
@@ -19,4 +19,12 @@ extension UIApplication {
         }
         return viewController
     }
+
+    class func openAppSetting() {
+        if #available(iOS 10.0, *) {
+            shared.open(URL(string: UIApplication.openSettingsURLString)!, options: [:], completionHandler: nil)
+        } else {
+            shared.openURL(URL(string: UIApplication.openSettingsURLString)!)
+        }
+    }
 }

--- a/NinchatSDKSwift/Implementations/Models/SiteConfiguration.swift
+++ b/NinchatSDKSwift/Implementations/Models/SiteConfiguration.swift
@@ -150,11 +150,20 @@ struct SiteConfigurationImpl: SiteConfiguration {
 
 extension SiteConfigurationImpl {
     private func value<T>(for key: String, ofType type: T.Type = T.self) -> T? {
-        debugger("Loading keys from environments: \(self.environments)")
         guard let configuration = configuration as? [String:Any] else { return nil }
+        var environments = self.environments
 
-        /// Insert "default" to beginning of given environments and start the lookup from the end of array
-        for env in [["default"], self.environments].joined().filter({ configuration[$0] != nil }).reversed() {
+        /// Insert "default" to the beginning of given environments
+        if !environments.contains("default") {
+            environments.insert("default", at: 0)
+        }
+
+        /// Lookup should be done from the last env to the first one
+        environments.reverse()
+        debugger("Loading keys from environments: \(environments)")
+
+        /// Start the lookup
+        for env in environments.filter({ configuration[$0] != nil }) {
             if let value = (configuration[env] as? [String:Any])?[key] as? T { return value }
         }
 

--- a/NinchatSDKSwift/Implementations/Models/SiteConfiguration.swift
+++ b/NinchatSDKSwift/Implementations/Models/SiteConfiguration.swift
@@ -153,12 +153,12 @@ extension SiteConfigurationImpl {
         debugger("Loading keys from environments: \(self.environments)")
         guard let configuration = configuration as? [String:Any] else { return nil }
 
-        /// Use given environments first, if any. Start the lookup from the end of array
-        if let value = self.environments.reversed().compactMap({ (configuration[$0] as? [String:Any])?[key] }).first as? T {
-            return value
+        /// Insert "default" to beginning of given environments and start the lookup from the end of array
+        for env in [["default"], self.environments].joined().filter({ configuration[$0] != nil }).reversed() {
+            if let value = (configuration[env] as? [String:Any])?[key] as? T { return value }
         }
 
-        /// Return value from default environment
-        return (configuration["default"] as? [String : Any])?[key] as? T
+        /// No value was found for given key in "default" + environments
+        return nil
     }
 }

--- a/NinchatSDKSwift/Implementations/View Model/NINQuestionnaireViewModel.swift
+++ b/NinchatSDKSwift/Implementations/View Model/NINQuestionnaireViewModel.swift
@@ -48,7 +48,7 @@ extension NINQuestionnaireViewModel {
     }
 
     func getAnswersForElement(_ element: QuestionnaireElement) -> AnyHashable? {
-        self.getAnswersForElement(element, presetOnly: false)
+        self.getAnswersForElement(element, presetOnly: true)
     }
 }
 
@@ -60,8 +60,8 @@ final class NINQuestionnaireViewModelImpl: NINQuestionnaireViewModel {
     private var configurations: [QuestionnaireConfiguration] = []
     internal var connector: QuestionnaireElementConnector!
     private var views: [[QuestionnaireElement]] = []
-    internal var answers: [String:AnyHashable]! = [:]
-    internal var preAnswers: [String:AnyHashable]! = [:]
+    internal var answers: [String:AnyHashable]! = [:]    // Contains answers saved by the user in the runtime
+    internal var preAnswers: [String:AnyHashable]! = [:] // Contains answers already given by the server
     private var setPageNumber: Int?
     private var setupConnectorOperation: BlockOperation!
     
@@ -299,17 +299,16 @@ extension NINQuestionnaireViewModelImpl {
 
     func getAnswersForElement(_ element: QuestionnaireElement, presetOnly: Bool = false) -> AnyHashable? {
         guard let configuration = element.elementConfiguration else { return nil }
-        if let value = self.answers[configuration.name], !presetOnly {
-            return value
-        }
         if let value = self.preAnswers[configuration.name] {
+            return value
+        } else if !presetOnly, let value = self.answers[configuration.name] {
             return value
         }
         return nil
     }
 
     func resetAnswer(for element: QuestionnaireElement) -> Bool {
-        guard let value = self.getAnswersForElement(element, presetOnly: true) as? String, self.requirementsSatisfied, element.isUserInteractionEnabled else {
+        guard let value = self.getAnswersForElement(element, presetOnly: false) as? String, self.requirementsSatisfied, element.isUserInteractionEnabled else {
             self.askedPageNumber = nil; return false
         }
 

--- a/NinchatSDKSwift/Implementations/View Model/NINQuestionnaireViewModel.swift
+++ b/NinchatSDKSwift/Implementations/View Model/NINQuestionnaireViewModel.swift
@@ -46,7 +46,6 @@ extension NINQuestionnaireViewModel {
     func logicTargetPage(for dictionary: [String:String], autoApply: Bool = true, performClosures: Bool = true) -> Int? {
         self.logicTargetPage(for: dictionary, autoApply: autoApply, performClosures: performClosures)
     }
-
     func getAnswersForElement(_ element: QuestionnaireElement) -> AnyHashable? {
         self.getAnswersForElement(element, presetOnly: true)
     }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Typing Cell/ChatTypingCell.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Typing Cell/ChatTypingCell.swift
@@ -52,7 +52,7 @@ final class ChatTypingCell: UITableViewCell {
         imageView.isHidden = !(config?.show ?? false)
         if let overrideURL = config?.imageOverrideURL {
             imageView.image(from: overrideURL)
-        } else {
+        } else if let url = url {
             imageView.image(from: url)
         }
     }
@@ -86,8 +86,8 @@ extension ChatTypingCell: TypingCell {
 // MARK: - LoadingCell
 
 extension ChatTypingCell: LoadingCell {
-    func populateLoading(name: String, imageAssets: NINImageAssetDictionary?, colorAssets: NINColorAssetDictionary?) {
-        self.senderNameLabel.text = name
+    func populateLoading(agentAvatarConfig: AvatarConfig, imageAssets: NINImageAssetDictionary?, colorAssets: NINColorAssetDictionary?) {
+        self.senderNameLabel.text = agentAvatarConfig.nameOverride
         self.timeLabel.text = ""
 
         /// Make Image view background match the bubble color
@@ -100,7 +100,7 @@ extension ChatTypingCell: LoadingCell {
 
         /// Apply asset overrides
         self.applyCommon(imageAssets: imageAssets, colorAssets: colorAssets)
-        self.imageView?.isHidden = true
+        self.apply(avatar: agentAvatarConfig, imageView: self.leftAvatarImageView, url: nil)
 
         /// Rotate the cell back to the normal
         self.rotate(0.0)

--- a/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Typing Cell/TypingCell.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Typing Cell/TypingCell.swift
@@ -11,5 +11,5 @@ protocol TypingCell: UIView {
 }
 
 protocol LoadingCell: UIView {
-    func populateLoading(name: String, imageAssets: NINImageAssetDictionary?, colorAssets: NINColorAssetDictionary?)
+    func populateLoading(agentAvatarConfig: AvatarConfig, imageAssets: NINImageAssetDictionary?, colorAssets: NINColorAssetDictionary?)
 }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Cells/QuestionnaireNavigationCell.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Cells/QuestionnaireNavigationCell.swift
@@ -20,16 +20,6 @@ final class QuestionnaireNavigationCell: UITableViewCell, QuestionnaireNavigatio
             self.decorateView()
         }
     }
-    var requirementsSatisfied: Bool = false {
-        didSet {
-            self.setSatisfaction(requirementsSatisfied)
-        }
-    }
-    var disabled: Bool = false {
-        didSet {
-            self.setDisableNavigations(disabled)
-        }
-    }
 
     var requirementSatisfactionUpdater: ((Bool) -> Void)?
     var onNextButtonTapped: (() -> Void)?
@@ -65,6 +55,16 @@ final class QuestionnaireNavigationCell: UITableViewCell, QuestionnaireNavigatio
             }
             backButton.layer.borderColor = delegate?.override(questionnaireAsset: .navigationBackText)?.cgColor ?? UIColor.QBlueButtonNormal.cgColor
             backButton.backgroundColor = delegate?.override(questionnaireAsset: .navigationBackBackground) ?? .white
+        }
+    }
+
+    func setSatisfaction(_ satisfied: Bool, lastItem: Bool) {
+        self.buttons.arrangedSubviews.compactMap({ $0 as? Button }).first(where: { $0.type == .next })?.isEnabled = satisfied
+        self.buttons.arrangedSubviews.compactMap({ $0 as? Button }).first(where: { $0.type == .next })?.alpha = (satisfied) ? 1.0 : 0.5
+
+        if !lastItem {
+            self.buttons.arrangedSubviews.compactMap({ $0 as? Button }).first(where: { $0.type == .back })?.isEnabled = satisfied
+            self.buttons.arrangedSubviews.compactMap({ $0 as? Button }).first(where: { $0.type == .back })?.alpha = (satisfied) ? 1.0 : 0.5
         }
     }
 
@@ -108,12 +108,9 @@ final class QuestionnaireNavigationCell: UITableViewCell, QuestionnaireNavigatio
     }
 
     private func setSatisfaction(_ satisfied: Bool) {
+        debugger("Set navigation Satisfaction: \(satisfied)")
         self.buttons.arrangedSubviews.compactMap({ $0 as? Button }).first(where: { $0.type == .next })?.isEnabled = satisfied
         self.buttons.arrangedSubviews.compactMap({ $0 as? Button }).first(where: { $0.type == .next })?.alpha = (satisfied) ? 1.0 : 0.5
-    }
-
-    private func setDisableNavigations(_ disable: Bool) {
-        self.buttons.subviews.compactMap({ $0 as? Button }).forEach({ $0.isEnabled = !disable; $0.alpha = (disable) ? 0.5 : 1.0 })
     }
 }
 
@@ -133,8 +130,6 @@ extension QuestionnaireNavigationCell {
     }
 
     func shapeNavigationButtons(_ configuration: QuestionnaireConfiguration?) {
-        self.buttons.arrangedSubviews.compactMap({ $0 as? Button }).forEach({ $0.removeFromSuperview() })
-
         func drawBackButton(isVisible: Bool) {
             if self.buttons.arrangedSubviews.compactMap({ $0 as? Button }).filter({ $0.type == .back }).count > 0 || !isVisible { return }
 
@@ -163,7 +158,6 @@ extension QuestionnaireNavigationCell {
         /// According to `https://github.com/somia/mobile/issues/238`
         /// " Basically you have buttons always displayed unless they are removed in config. "
         /// " But it should omit 'back' for the first element "
-
         drawBackButton(isVisible: self.shouldShowBackButton)
         addSeparator(isVisible: self.shouldShowNextButton || self.shouldShowBackButton)
         drawNextButton(isVisible: self.shouldShowNextButton)

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementCheckbox.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementCheckbox.swift
@@ -50,14 +50,8 @@ final class QuestionnaireElementCheckbox: UIView, QuestionnaireElementWithTitle,
     // MARK: - QuestionnaireSettable
 
     func updateSetAnswers(_ answer: AnyHashable?, state: QuestionnaireSettableState) {
-        guard let answer = answer as? String, let option = self.elementConfiguration?.options?.first(where: { $0.value == answer }) else { return }
-
-        switch state {
-        case .set:
-            self.select(option: option)
-        case .nothing:
-            break
-        }
+        guard let option = self.elementConfiguration?.options?.first(where: { $0.value == answer as? String }) else { return }
+        self.select(option: option)
     }
 
     // MARK: - QuestionnaireOptionSelectableElement

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementRadio.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementRadio.swift
@@ -51,7 +51,7 @@ class QuestionnaireElementRadio: UIView, QuestionnaireElementWithTitle, Question
         case .set:
             button.closure?(button)
         case .nothing:
-            break
+            debugger("Do nothing for Radio element")
         }
     }
 

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementSelect.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementSelect.swift
@@ -35,7 +35,7 @@ final class QuestionnaireElementSelect: UIView, QuestionnaireElementWithTitle, Q
     }
     var elementConfiguration: QuestionnaireConfiguration?
     var elementHeight: CGFloat {
-        self.title.frame.origin.y + self.title.intrinsicContentSize.height + self.heightValue + 8.0 + self.padding
+        self.title.frame.origin.y + self.title.intrinsicContentSize.height + self.heightValue + self.padding
     }
 
     func overrideAssets(with delegate: NINChatSessionInternalDelegate?) {

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementSelect.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementSelect.swift
@@ -50,14 +50,8 @@ final class QuestionnaireElementSelect: UIView, QuestionnaireElementWithTitle, Q
     // MARK: - QuestionnaireSettable
 
     func updateSetAnswers(_ answer: AnyHashable?, state: QuestionnaireSettableState) {
-        guard let answer = answer as? String, let option = self.elementConfiguration?.options?.first(where: { $0.value == answer }) else { return }
-
-        switch state {
-        case .set:
-            self.select(option: option)
-        case .nothing:
-            break
-        }
+        guard let option = self.elementConfiguration?.options?.first(where: { $0.value == answer as? String }) else { return }
+        self.select(option: option, state: state)
         self.updateBorder()
     }
 
@@ -154,17 +148,24 @@ extension QuestionnaireElementSelect {
                 self?.deselect(option: option)
             case .select(let index):
                 guard let option = self?.elementConfiguration?.options?[index] else { fatalError("Unable to pick selected option") }
-                self?.select(option: option)
+                self?.select(option: option, state: .set)
             }
             self?.updateBorder()
         }
     }
 
-    private func select(option: ElementOption) {
+    private func select(option: ElementOption, state: QuestionnaireSettableState) {
         self.selectedOption.isHighlighted = true
         self.selectedOption.text = option.label
         self.view.backgroundColor = selectedBackgroundColor
-        self.onElementOptionSelected?(option)
+
+        switch state {
+        case .set:
+            self.onElementOptionSelected?(option)
+        case .nothing:
+            debugger("Do nothing for Select element")
+        }
+
     }
 
     func deselect(option: ElementOption) {

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementText.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementText.swift
@@ -11,9 +11,6 @@ final class QuestionnaireElementText: UITextView, QuestionnaireElement {
     fileprivate var conversationStylePadding: CGFloat {
         (self.questionnaireStyle == .conversation) ? 75 : 0
     }
-    private var estimatedWidth: CGFloat {
-        (UIApplication.topViewController()?.view.bounds ?? UIScreen.main.bounds).width - conversationStylePadding
-    }
 
     // MARK: - QuestionnaireElement
 
@@ -35,12 +32,12 @@ final class QuestionnaireElementText: UITextView, QuestionnaireElement {
     }
     var elementConfiguration: QuestionnaireConfiguration?
     var elementHeight: CGFloat {
-        self.estimateHeight(width: self.estimatedWidth)
+        self.estimateHeight(width: self.estimatedWidth())
     }
 
     func overrideAssets(with delegate: NINChatSessionInternalDelegate?) {
         if let overriddenColor = delegate?.override(questionnaireAsset: .titleTextColor) {
-            self.setAttributed(text: self.elementConfiguration?.label ?? "", font: .ninchat, color: overriddenColor, width:  self.estimatedWidth - 24.0)
+            self.setAttributed(text: self.elementConfiguration?.label ?? "", font: .ninchat, color: overriddenColor, width:  self.estimatedWidth())
         }
     }
 
@@ -69,15 +66,20 @@ final class QuestionnaireElementText: UITextView, QuestionnaireElement {
     }
 
     func estimateHeight(width: CGFloat) -> CGFloat {
-        max(24,0, self.sizeThatFits(CGSize(width: width, height: .greatestFiniteMagnitude)).height)
+        self.sizeThatFits(CGSize(width: width, height: .greatestFiniteMagnitude)).height
     }
+    
+    fileprivate func estimatedWidth() -> CGFloat {
+        (UIApplication.topViewController()?.view.bounds ?? UIScreen.main.bounds).width - conversationStylePadding - 2.0
+    }
+
 }
 
 extension QuestionnaireElement where Self:QuestionnaireElementText {
     func shapeView(_ configuration: QuestionnaireConfiguration?) {
         self.textAlignment = .left
         self.backgroundColor = .clear
-        self.setAttributed(text: configuration?.label ?? "", font: .ninchat, width: UIScreen.main.bounds.width - self.conversationStylePadding - 21.0)
+        self.setAttributed(text: configuration?.label ?? "", font: .ninchat, width: self.estimatedWidth())
         self.elementConfiguration = configuration
     }
 }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextArea.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextArea.swift
@@ -43,13 +43,15 @@ final class QuestionnaireElementTextArea: UIView, QuestionnaireElementWithTitle,
 
     func updateSetAnswers(_ answer: AnyHashable?, state: QuestionnaireSettableState) {
         guard let answer = answer as? String else { return }
+        self.view.text = answer
+
         switch state {
         case .set:
-            self.view.text = answer
+            self.textViewDidEndEditing(self.view)
         case .nothing:
-            break
+            debugger("Do nothing for TextArea element")
         }
-        self.textViewDidEndEditing(self.view)
+
     }
 
     // MARK: - QuestionnaireHasBorder

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextArea.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextArea.swift
@@ -9,6 +9,7 @@ import UIKit
 final class QuestionnaireElementTextArea: UIView, QuestionnaireElementWithTitle, QuestionnaireSettable, QuestionnaireHasBorder, QuestionnaireFocusableElement {
 
     fileprivate var heightValue: CGFloat = 98.0
+    private var answerUpdateWorker: DispatchWorkItem?
 
     // MARK: - QuestionnaireElement
 
@@ -126,6 +127,12 @@ extension QuestionnaireElementTextArea: UITextViewDelegate {
     }
 
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        self.answerUpdateWorker?.cancel()
+        self.answerUpdateWorker = DispatchWorkItem { [weak self] in
+            guard let weakSelf = self else { return }
+            weakSelf.onElementDismissed?(weakSelf)
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: self.answerUpdateWorker!)
         self.isCompleted = isCompleted(text: (textView.text ?? "") + text)
         return true
     }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextArea.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextArea.swift
@@ -31,7 +31,7 @@ final class QuestionnaireElementTextArea: UIView, QuestionnaireElementWithTitle,
     }
     var elementConfiguration: QuestionnaireConfiguration?
     var elementHeight: CGFloat {
-        self.title.frame.origin.y + self.title.intrinsicContentSize.height + self.heightValue + 8.0 + self.padding
+        self.title.frame.origin.y + self.title.intrinsicContentSize.height + self.heightValue + self.padding
     }
 
     func overrideAssets(with delegate: NINChatSessionInternalDelegate?) {

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextField.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextField.swift
@@ -31,7 +31,7 @@ final class QuestionnaireElementTextField: UIView, QuestionnaireElementWithTitle
     }
     var elementConfiguration: QuestionnaireConfiguration?
     var elementHeight: CGFloat {
-        self.title.frame.origin.y + self.title.intrinsicContentSize.height + self.heightValue + 4.0 + self.padding
+        self.title.frame.origin.y + self.title.intrinsicContentSize.height + self.heightValue + self.padding
     }
 
     func overrideAssets(with delegate: NINChatSessionInternalDelegate?) {

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextField.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextField.swift
@@ -9,6 +9,7 @@ import UIKit
 final class QuestionnaireElementTextField: UIView, QuestionnaireElementWithTitle, QuestionnaireSettable, QuestionnaireHasBorder, QuestionnaireFocusableElement {
 
     fileprivate var heightValue: CGFloat = 45.0
+    private var answerUpdateWorker: DispatchWorkItem?
 
     // MARK: - QuestionnaireElement
 
@@ -125,6 +126,12 @@ extension QuestionnaireElementTextField: UITextFieldDelegate {
     }
 
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        self.answerUpdateWorker?.cancel()
+        self.answerUpdateWorker = DispatchWorkItem { [weak self] in
+            guard let weakSelf = self else { return }
+            weakSelf.onElementDismissed?(weakSelf)
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: self.answerUpdateWorker!)
         self.isCompleted = isCompleted(text: (textField.text ?? "") + string)
         return true
     }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextField.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextField.swift
@@ -43,13 +43,14 @@ final class QuestionnaireElementTextField: UIView, QuestionnaireElementWithTitle
 
     func updateSetAnswers(_ answer: AnyHashable?, state: QuestionnaireSettableState) {
         guard let answer = answer as? String else { return }
+        self.view.text = answer
+
         switch state {
         case .set:
-            self.view.text = answer
+            self.textFieldDidEndEditing(self.view)
         case .nothing:
-            break
+            debugger("Do nothing for TextField element")
         }
-        self.textFieldDidEndEditing(self.view)
     }
 
     // MARK: - QuestionnaireHasBorder

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/QuestionnaireElement.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/QuestionnaireElement.swift
@@ -116,7 +116,20 @@ extension QuestionnaireElementWithTitle {
 protocol QuestionnaireFocusableElement {
     var onElementFocused: ((QuestionnaireElement) -> Void)? { get set }
     var onElementDismissed: ((QuestionnaireElement) -> Void)? { get set }
+
+    func clearAll()
 }
+extension QuestionnaireFocusableElement where Self:QuestionnaireElementTextArea {
+    func clearAll() {
+        self.view.text = ""
+    }
+}
+extension QuestionnaireFocusableElement where Self:QuestionnaireElementTextField {
+    func clearAll() {
+        self.view.text = ""
+    }
+}
+
 
 /// Add select/deselect closure for applicable elements (e.g. radio, checkbox)
 protocol QuestionnaireOptionSelectableElement {

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/QuestionnaireElement.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/QuestionnaireElement.swift
@@ -49,8 +49,8 @@ extension QuestionnaireElementWithTitle {
     }
 
     var padding: CGFloat {
-        guard let title = self.title.text else { return 8.0 }
-        return (self.questionnaireStyle == .form || title.isEmpty) ? 8.0 : 20.0
+        guard let title = self.title.text, !title.isEmpty else { return 8.0 }
+        return self.questionnaireStyle == .form ? 32.0 : 40.0
     }
 
     func addElementViews() {

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINInitialViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINInitialViewController.swift
@@ -106,7 +106,7 @@ private extension NINInitialViewController {
     private func drawQueueButtons() {
         self.queueButtonsStackView.subviews.forEach { $0.removeFromSuperview() }
 
-        let availableQueues = self.session?.sessionManager.audienceQueues.filter({ !$0.isClosed }) ?? []
+        let availableQueues = self.sessionManager?.audienceQueues.filter({ !$0.isClosed }) ?? []
         let numberOfButtons = min(3, availableQueues.count)
         let buttonHeights: CGFloat = (numberOfButtons > 2) ? 40.0 : 60.0
         for index in 0..<numberOfButtons {
@@ -119,7 +119,7 @@ private extension NINInitialViewController {
             button.contentEdgeInsets = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10)
             button.backgroundColor = .defaultBackgroundButton
             button.setTitleColor(.white, for: .normal)
-            button.setTitle(self.session?.sessionManager.translate(key: Constants.kJoinQueueText.rawValue, formatParams: ["audienceQueue.queue_attrs.name": queue.name]) ?? "", for: .normal)
+            button.setTitle(self.sessionManager?.translate(key: Constants.kJoinQueueText.rawValue, formatParams: ["audienceQueue.queue_attrs.name": queue.name]) ?? "", for: .normal)
             button.overrideAssets(with: self.session?.internalDelegate, isPrimary: true)
             
             queueButtonsStackView.addArrangedSubview(button)
@@ -130,6 +130,6 @@ private extension NINInitialViewController {
     private func drawNoQueueText() {
         self.queueButtonsStackView.isHidden = true
         self.noQueueTextView.isHidden = false
-        self.noQueueTextView.setAttributed(text: self.session?.sessionManager.siteConfiguration.noQueueText ?? NSLocalizedString("NoQueueText", tableName: "Localizable", bundle: Bundle.SDKBundle!, value: "", comment: ""), font: self.noQueueTextView.font)
+        self.noQueueTextView.setAttributed(text: self.sessionManager?.siteConfiguration.noQueueText ?? NSLocalizedString("NoQueueText", tableName: "Localizable", bundle: Bundle.SDKBundle!, value: "", comment: ""), font: self.noQueueTextView.font)
     }
 }

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINInitialViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINInitialViewController.swift
@@ -19,9 +19,9 @@ final class NINInitialViewController: UIViewController {
     
     // MARK: - Outlets
     
-    @IBOutlet private(set) weak var topContainerView: UIView!
-    @IBOutlet private(set) weak var bottomContainerView: UIView!
-    @IBOutlet private(set) weak var welcomeTextView: UITextView! {
+    @IBOutlet private(set) var topContainerView: UIView!
+    @IBOutlet private(set) var bottomContainerView: UIView!
+    @IBOutlet private(set) var welcomeTextView: UITextView! {
         didSet {
             if let welcomeText = self.sessionManager?.siteConfiguration.welcome {
                 welcomeTextView.setAttributed(text: welcomeText, font: .ninchat)
@@ -29,8 +29,8 @@ final class NINInitialViewController: UIViewController {
             }
         }
     }
-    @IBOutlet private(set) weak var queueButtonsStackView: UIStackView!
-    @IBOutlet private(set) weak var closeWindowButton: Button! {
+    @IBOutlet private(set) var queueButtonsStackView: UIStackView!
+    @IBOutlet private(set) var closeWindowButton: Button! {
         didSet {
             if let closeText = self.sessionManager?.translate(key: Constants.kCloseWindowText.rawValue, formatParams: [:]) {
                 closeWindowButton.setTitle(closeText, for: .normal)
@@ -38,7 +38,7 @@ final class NINInitialViewController: UIViewController {
             closeWindowButton.round(borderWidth: 1.0, borderColor: .defaultBackgroundButton)
         }
     }
-    @IBOutlet private(set) weak var motdTextView: UITextView! {
+    @IBOutlet private(set) var motdTextView: UITextView! {
         didSet {
             if let motdText = self.sessionManager?.siteConfiguration.motd {
                 motdTextView.setAttributed(text: motdText, font: .ninchat)
@@ -47,7 +47,7 @@ final class NINInitialViewController: UIViewController {
             motdTextView.textAlignment = .left
         }
     }
-    @IBOutlet private(set) weak var noQueueTextView: UITextView! {
+    @IBOutlet private(set) var noQueueTextView: UITextView! {
         didSet {
             self.noQueueTextView.isHidden = true
         }
@@ -62,7 +62,6 @@ final class NINInitialViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.overrideAssets()
         if self.sessionManager?.audienceQueues.filter({ !$0.isClosed }).count ?? 0 > 0 {
             /// There is at least one open queue to join
             self.drawQueueButtons()
@@ -72,6 +71,11 @@ final class NINInitialViewController: UIViewController {
         }
     }
     
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        self.overrideAssets()
+    }
+
     // MARK: - User actions
     
     @IBAction private func closeWindowButtonPressed(button: UIButton) {
@@ -83,7 +87,7 @@ final class NINInitialViewController: UIViewController {
 
 private extension NINInitialViewController {
     private func overrideAssets() {
-        closeWindowButton.overrideAssets(with: self.session?.internalDelegate, isPrimary: false)
+        closeWindowButton?.overrideAssets(with: self.session?.internalDelegate, isPrimary: false)
         if let topBackgroundColor = self.session?.internalDelegate?.override(colorAsset: .backgroundTop) {
             topContainerView.backgroundColor = topBackgroundColor
         }

--- a/NinchatSDKSwiftTests/PermissionTests.swift
+++ b/NinchatSDKSwiftTests/PermissionTests.swift
@@ -40,4 +40,15 @@ final class PermissionTests: XCTestCase {
         
         waitForExpectations(timeout: 5.0)
     }
+    
+    func test_permissions_multiple() {
+        let expect = self.expectation(description: "Expected to get all permissions with the same errors")
+        Permission.grantPermission(.devicePhotoLibrary, .deviceMicrophone, .deviceCamera) { (error) in
+            XCTAssertNotNil(error)
+            XCTAssertEqual(error, .permissionDenied)
+            expect.fulfill()
+        }
+        
+        waitForExpectations(timeout: 5.0)
+    }
 }

--- a/NinchatSDKSwiftTests/Resources/site-configuration-mock.json
+++ b/NinchatSDKSwiftTests/Resources/site-configuration-mock.json
@@ -16,7 +16,6 @@
       "noQueuesText": "Liittymiseen ei ole avoimia jonoja (noQueuesText)",
       "motd": "Hieno meno öäå <br>https://ninchat.com/contact",
       "newUI": true,
-      "sendButtonText": "Lähetä",
       "supportFiles": false,
       "supportVideo": false,
       "translations": {
@@ -828,5 +827,635 @@
           }
         }
       ]
+    },
+    "fi": {
+      "welcome": "fi",
+      "motd": "",
+      "postAudienceQuestionnaireStyle": "conversation",
+      "preAudienceQuestionnaireStyle": "conversation",
+      "questionnaireAvatar": "https://ninchat.com/customer/terveystalo/omaterveys/avatar-mieli.png",
+      "questionnaireName": "Mielen-botti",
+      "preAudienceQuestionnaire": [
+        {
+          "element": "textarea",
+          "label": "Tervetuloa Mielen chattiin! Olen Terveystalon chat-robotti. Kysyn sinulta alkuun viisi kysymystä ja ohjaan sinut sitten keskustelemaan hoitajan kanssa. Kerrotko vähän, mitä sinulle kuuluu?",
+          "name": "Syy",
+          "buttons": {
+            "back": false
+          },
+          "redirects": [
+            {
+              "target": "SUD"
+            }
+          ]
+        },
+        {
+          "element": "radio",
+          "label": "Hyvä, kiitos. Kun nyt ajattelet noita mielessäsi pyöriviä asioita, kerrotko kuinka häiritseviltä ne juuri nyt tuntuvat. Merkitse asteikolle häiritsevyyden määrä asteikolla nollasta kymmeneen, jolloin nolla tarkoittaa, että sinulla on neutraali ja rauhallinen olo ja kymmenen tarkoittaa, että asia häiritsee sinua todella kovasti.",
+          "name": "SUD",
+          "buttons": {
+            "back": false,
+            "next": false
+          },
+          "options": [
+            {
+              "value": "0",
+              "label": "0"
+            },
+            {
+              "value": "1",
+              "label": "1"
+            },
+            {
+              "value": "2",
+              "label": "2"
+            },
+            {
+              "value": "3",
+              "label": "3"
+            },
+            {
+              "value": "4",
+              "label": "4"
+            },
+            {
+              "value": "5",
+              "label": "5"
+            },
+            {
+              "value": "6",
+              "label": "6"
+            },
+            {
+              "value": "7",
+              "label": "7"
+            },
+            {
+              "value": "8",
+              "label": "8"
+            },
+            {
+              "value": "9",
+              "label": "9"
+            },
+            {
+              "value": "10",
+              "label": "10"
+            }
+          ],
+          "redirects": [
+            {
+              "target": "PHQ 1"
+            }
+          ]
+        },
+        {
+          "element": "radio",
+          "label": "Seuraavat kaksi kysymystä kartoittavat vähän mielialaasi.Oletko viimeisen kahden viikon aikana ollut aiempaa vähemmän kiinnostunut tavallisten asioiden tekemisestä tai saanut niistä vain vähän (tai et juuri lainkaan) mielihyvän tunnetta?",
+          "name": "PHQ 1",
+          "buttons": {
+            "back": false,
+            "next": false
+          },
+          "options": [
+            {
+              "value": "0",
+              "label": "En lainkaan"
+            },
+            {
+              "value": "1",
+              "label": "Useina päivinä"
+            },
+            {
+              "value": "2",
+              "label": "Enemmän kuin puolet ajasta"
+            },
+            {
+              "value": "3",
+              "label": "Lähes joka päivä"
+            }
+          ],
+          "redirects": [
+            {
+              "target": "PHQ 2"
+            }
+          ]
+        },
+        {
+          "element": "radio",
+          "label": "Oletko viimeisen kahden viikon aikana kokenut mielialasi alakuloiseksi, masentuneeksi tai toivottomaksi?",
+          "name": "PHQ 2",
+          "buttons": {
+            "back": false,
+            "next": false
+          },
+          "options": [
+            {
+              "value": "0",
+              "label": "En lainkaan"
+            },
+            {
+              "value": "1",
+              "label": "Useina päivinä"
+            },
+            {
+              "value": "2",
+              "label": "Enemmän kuin puolet ajasta"
+            },
+            {
+              "value": "3",
+              "label": "Lähes joka päivä"
+            }
+          ],
+          "redirects": [
+            {
+              "target": "Hyvät asiat"
+            }
+          ]
+        },
+        {
+          "element": "textarea",
+          "label": "Kerrotko vielä, mitkä asiat ovat elämässäsi tällä hetkellä hyvin? Mistä saat hyvän mielen?",
+          "name": "Hyvät asiat",
+          "buttons": {
+            "back": false,
+            "next": "Aloita chat"
+          }
+        }
+      ],
+      "postAudienceQuestionnaire": [
+        {
+          "element": "textarea",
+          "label": "Haluatko vielä jättää vapaata palautetta meille? Arvostamme kaikenlaista palautetta ja pyrimme kehittämään palvelua sen avulla.",
+          "name": "Palaute",
+          "buttons": {
+            "back": false,
+            "next": "Lähetä"
+          }
+        }
+      ],
+      "agentAvatar": null,
+      "closeConfirmText": "Lopettaminen päättää käydyn keskustelun. Haluatko varmasti lopettaa?",
+      "sendButtonText": null,
+      "translations": {
+        "Join audience queue {{audienceQueue.queue_attrs.name}}": "Aloita chatti",
+        "Join audience queue {{audienceQueue.queue_attrs.name}} (closed)": " ",
+        "Joined audience queue {{audienceQueue.queue_attrs.name}}, you are at position {{audienceQueue.queue_position}}.": "Kiitos! Ohjaan sinut nyt hoitajan chat-vastaanotolle.<br><br>Olet jonossa sijalla {{audienceQueue.queue_position}}.<br>Odota, että Terveystalon asiantuntija poimii sinut jonosta.",
+        "Audience in queue {{queue}} accepted.": "Keskustelu aloitettu.",
+        "Joined audience queue {{audienceQueue.queue_attrs.name}}, you are next.": "Kiitos! Ohjaan sinut nyt hoitajan chat-vastaanotolle.<br>Olet seuraavana vuorossa.<br>Odota, että Terveystalon asiantuntija poimii sinut jonosta.",
+        "Enter your message": "Kirjoita viesti",
+        "Conversation ended": "Keskustelu on päättynyt. Voit sulkea chatin.",
+        "Skip": "Ohita",
+        "You are invited to a video call": "Lääkäri kutsui sinut videokeskusteluun. Klikkaa kamera-ikonia aloittaaksesi.",
+        "Video call declined": "Videokeskustelu hylätty",
+        "Video call answered": "Videokeskustelu aloitettu",
+        "Toggle fullscreen": "Koko ruutu -tila on/off",
+        "Toggle audio": "Ääni on/off",
+        "Toggle microphone": "Mykistä mikrofoni",
+        "Toggle video": "Video on/off",
+        "End video call": "Lopeta videokeskustelu",
+        "Add an emoji": "Lisää emoji",
+        "How was our customer service?": "<strong>Miten asiointisi onnistui?</strong>",
+        "Next": "Jatka",
+        "Close window": "Sulje ikkuna",
+        "Submit": "Lähetä",
+        "Close chat": "Sulje keskustelu",
+        "Continue chat": "Jatka keskustelua",
+        "Good": "Hyvin",
+        "Okay": "Ok",
+        "Poor": "Huonosti",
+        "Accept": "Hyväksy",
+        "Decline": "Hylkää",
+        "You are invited to a video chat": "Sinut on kutsuttu videokeskusteluun",
+        "wants to video chat with you": "haluaa aloittaa videokeskustelun"
+      },
+      "inQueueText": " ",
+      "noQueuesText": " "
+    },
+    "fi-restart": {
+      "audienceRealmId": "5lmphjc200m3g",
+      "audienceQueues": [
+        "5lmpjrbl00m3g"
+      ],
+      "welcome": "fi-restart",
+      "audienceAutoQueue": null
+    },
+    "en": {
+      "preAudienceQuestionnaire": [
+        {
+          "element": "textarea",
+          "label": "Welcome to Mielen chat! I’m Terveystalo’s chatbot, and I’d like to start off by asking you five questions before connecting you with one of our nurses. Firstly, could you tell me a bit about what’s on your mind right now?",
+          "name": "Syy",
+          "buttons": {
+            "back": false
+          },
+          "redirects": [
+            {
+              "target": "SUD"
+            }
+          ]
+        },
+        {
+          "element": "radio",
+          "label": "Thank you. Next, thinking about the issues you have on your mind right now, how much are they bothering you? Please give an estimate on a scale of 0-10, 0 being neutral and calm, and 10 being incredibly worrisome.",
+          "name": "SUD",
+          "buttons": {
+            "back": false,
+            "next": false
+          },
+          "options": [
+            {
+              "value": "0",
+              "label": "0"
+            },
+            {
+              "value": "1",
+              "label": "1"
+            },
+            {
+              "value": "2",
+              "label": "2"
+            },
+            {
+              "value": "3",
+              "label": "3"
+            },
+            {
+              "value": "4",
+              "label": "4"
+            },
+            {
+              "value": "5",
+              "label": "5"
+            },
+            {
+              "value": "6",
+              "label": "6"
+            },
+            {
+              "value": "7",
+              "label": "7"
+            },
+            {
+              "value": "8",
+              "label": "8"
+            },
+            {
+              "value": "9",
+              "label": "9"
+            },
+            {
+              "value": "10",
+              "label": "10"
+            }
+          ],
+          "redirects": [
+            {
+              "target": "PHQ 1"
+            }
+          ]
+        },
+        {
+          "element": "radio",
+          "label": "The next two questions are meant to map out your current state of mind. Over the past two weeks, have you felt less interested in doing everyday things, or have you gotten less (or no) pleasure from doing them?",
+          "name": "PHQ 1",
+          "buttons": {
+            "back": false,
+            "next": false
+          },
+          "options": [
+            {
+              "value": "1",
+              "label": "Not at all"
+            },
+            {
+              "value": "2",
+              "label": "On several days"
+            },
+            {
+              "value": "3",
+              "label": "More than half the time"
+            },
+            {
+              "value": "4",
+              "label": "Almost every day"
+            }
+          ],
+          "redirects": [
+            {
+              "target": "PHQ 2"
+            }
+          ]
+        },
+        {
+          "element": "radio",
+          "label": "Over the past two weeks, have you been feeling down, depressed, or hopeless?  ",
+          "name": "PHQ 2",
+          "buttons": {
+            "back": false,
+            "next": false
+          },
+          "options": [
+            {
+              "value": "1",
+              "label": "Not at all"
+            },
+            {
+              "value": "2",
+              "label": "On several days"
+            },
+            {
+              "value": "3",
+              "label": "More than half the time"
+            },
+            {
+              "value": "4",
+              "label": "Almost every day"
+            }
+          ],
+          "redirects": [
+            {
+              "target": "Hyvät asiat"
+            }
+          ]
+        },
+        {
+          "element": "textarea",
+          "label": "Lastly, could you tell me about the things that are well in your life right now? What are the things that make you feel good?",
+          "name": "Hyvät asiat",
+          "buttons": {
+            "back": false,
+            "next": "Aloita chat"
+          }
+        }
+      ],
+      "postAudienceQuestionnaire": [
+        {
+          "element": "text",
+          "label": "Give us feedback!<br>If you want us to contact you, please leave your contact information as well.",
+          "name": "feedbackDescription"
+        },
+        {
+          "element": "textarea",
+          "label": "Feedback",
+          "name": "Palaute"
+        },
+        {
+          "element": "textarea",
+          "label": "Contact information",
+          "name": "Yhteystiedot"
+        }
+      ],
+      "agentAvatar": null,
+      "css": "https://ninchat.com/customer/terveystalo/omaterveys/ninchat-mieli-en.css?v=1.7",
+      "language": "en",
+      "closeConfirmText": "Closing the chat will terminate the discussion. Are you sure you wish to close the chat?",
+      "sendButtonText": "Send",
+      "translations": {
+        "Join audience queue {{audienceQueue.queue_attrs.name}}": "Start the chat",
+        "Join audience queue {{audienceQueue.queue_attrs.name}} (closed)": "The chat is closed",
+        "Joined audience queue {{audienceQueue.queue_attrs.name}}, you are at position {{audienceQueue.queue_position}}.": "Thank you! Next, I’ll connect you with one of our nurses.<br>You are #{{audienceQueue.queue_position}} in line.",
+        "Audience in queue {{queue}} accepted.": "Chat has started.",
+        "Joined audience queue {{audienceQueue.queue_attrs.name}}, you are next.": "Thank you! Next, I’ll connect you with one of our nurses.<b>Just a moment, you are next in line.",
+        "Enter your message": "Enter your message",
+        "Conversation ended": "Chat opened. One of our nurses is reading your messages and will answer you in a moment.",
+        "Skip": "Skip",
+        "You are invited to a video call": "Doctor invited you to video call. Click the camera-symbol to start.",
+        "Video call declined": "Video call declined",
+        "Video call answered": "Video call started",
+        "Toggle fullscreen": "Full screen on/off",
+        "Toggle audio": "Audio on/off",
+        "Toggle microphone": "Mute the microphone",
+        "Toggle video": "Video on/off",
+        "End video call": "Close the video call",
+        "Close chat": "Close conversation",
+        "Add an emoji": "Add an emoji",
+        "How was our customer service?": "<p><strong>How did we succeed in helping you?</strong></p>",
+        "Next": "Continue"
+      },
+      "welcome": " ",
+      "inQueueText": " ",
+      "noQueuesText": " ",
+      "motd": " "
+    },
+    "sv": {
+      "preAudienceQuestionnaire": [
+        {
+          "element": "textarea",
+          "label": "Välkommen till Mielen chat! Jag är Terveystalos chat-robot och börjar med att fråga fem frågor av dig. Därefter hänvisar jag dig till en av våra chat-skötare. Skulle du först kunna berätta om hur du mår?",
+          "name": "Syy",
+          "buttons": {
+            "back": false
+          },
+          "redirects": [
+            {
+              "target": "SUD"
+            }
+          ]
+        },
+        {
+          "element": "radio",
+          "label": "Tack, när du tänker på de saker du skrivit om och som du har i tankarna, hur störande upplever du dem just nu? Bedöm detta på en skala från 0-10, där 0 betyder att du känner dig lugn och neutral och 10 betyder att dessa saker stör dig väldigt mycket.",
+          "name": "SUD",
+          "buttons": {
+            "back": false,
+            "next": false
+          },
+          "options": [
+            {
+              "value": "0",
+              "label": "0"
+            },
+            {
+              "value": "1",
+              "label": "1"
+            },
+            {
+              "value": "2",
+              "label": "2"
+            },
+            {
+              "value": "3",
+              "label": "3"
+            },
+            {
+              "value": "4",
+              "label": "4"
+            },
+            {
+              "value": "5",
+              "label": "5"
+            },
+            {
+              "value": "6",
+              "label": "6"
+            },
+            {
+              "value": "7",
+              "label": "7"
+            },
+            {
+              "value": "8",
+              "label": "8"
+            },
+            {
+              "value": "9",
+              "label": "9"
+            },
+            {
+              "value": "10",
+              "label": "10"
+            }
+          ],
+          "redirects": [
+            {
+              "target": "PHQ 1"
+            }
+          ]
+        },
+        {
+          "element": "radio",
+          "label": "De följande två frågorna kartlägger din sinnesstämning. Har du under de två senaste veckorna varit mindre intresserad av attgöra vardagliga saker eller känt enbart lite (eller inte alls) glädje av att göra dem?",
+          "name": "PHQ 1",
+          "buttons": {
+            "back": false,
+            "next": false
+          },
+          "options": [
+            {
+              "value": "1",
+              "label": "Inte alls"
+            },
+            {
+              "value": "2",
+              "label": "Flera dagar"
+            },
+            {
+              "value": "3",
+              "label": "Mera än hälften av dagarna"
+            },
+            {
+              "value": "4",
+              "label": "Nstan varje dag"
+            }
+          ],
+          "redirects": [
+            {
+              "target": "PHQ 2"
+            }
+          ]
+        },
+        {
+          "element": "radio",
+          "label": "Har du känt dig nedstämd, deprimerad eller hopplös under de senaste två veckorna?",
+          "name": "PHQ 2",
+          "buttons": {
+            "back": false,
+            "next": false
+          },
+          "options": [
+            {
+              "value": "1",
+              "label": "Inte alls"
+            },
+            {
+              "value": "2",
+              "label": "Flera dagar"
+            },
+            {
+              "value": "3",
+              "label": "Mera än hälften av dagarna"
+            },
+            {
+              "value": "4",
+              "label": "Nstan varje dag"
+            }
+          ],
+          "redirects": [
+            {
+              "target": "Hyvät asiat"
+            }
+          ]
+        },
+        {
+          "element": "textarea",
+          "label": "Till sist, kan du ännu berätta vilka saker som är bra i ditt liv just nu? Vad ger dig glädje?",
+          "name": "Hyvät asiat",
+          "buttons": {
+            "back": false,
+            "next": "Börja chat"
+          }
+        }
+      ],
+      "postAudienceQuestionnaire": [
+        {
+          "element": "text",
+          "label": "Ge oss feedback!<br>Om du vill att vi kontaktar dig, vänligen ge oss också dina kontaktuppgifter.",
+          "name": "feedbackDescription"
+        },
+        {
+          "element": "textarea",
+          "label": "Feedback",
+          "name": "Palaute"
+        },
+        {
+          "element": "textarea",
+          "label": "Kontaktuppgifter",
+          "name": "Yhteystiedot"
+        }
+      ],
+      "agentAvatar": null,
+      "css": "https://ninchat.com/customer/terveystalo/omaterveys/ninchat-mieli-sv.css?v=1.7",
+      "language": "sv",
+      "closeConfirmText": "Om du stänger chatten avslutar du konversationen. Är du säker på att du vill stänga chatten?",
+      "sendButtonText": "Skicka",
+      "translations": {
+        "Join audience queue {{audienceQueue.queue_attrs.name}}": "Starta chatten",
+        "Join audience queue {{audienceQueue.queue_attrs.name}} (closed)": "Chattmottagningen är stängd",
+        "Joined audience queue {{audienceQueue.queue_attrs.name}}, you are at position {{audienceQueue.queue_position}}.": "Tack! Nu hänvisar jag dig vidare till chat-mottagningen.<br>Du är #{{audienceQueue.queue_position}} i kön.",
+        "Joined audience queue {{audienceQueue.queue_attrs.name}}, you are next.": "Tack! Nu hänvisar jag dig vidare till chat-mottagningen.<br>Ett ögonblick, du är först i kön.",
+        "Audience in queue {{queue}} accepted.": "Chatten är öppen. En av våra chat-skötare läser dina meddelanden och svarar dig snart.",
+        "Enter your message": "Skriv in ditt meddelande",
+        "Conversation ended": "Konversationen är avslutad. Du kan stänga chatten.",
+        "Skip": "Hoppa över",
+        "You are invited to a video call": "Läkare vill starta en video samtal. Klicka en kamera-symbol och börja.",
+        "Video call declined": "Videosamtal nekades",
+        "Video call answered": "Videosamtal har startat",
+        "Toggle fullscreen": "Fullskärm on/off",
+        "Toggle audio": "Audio on/off",
+        "Toggle microphone": "Stäng av mikrofonen",
+        "Toggle video": "Video on/off",
+        "End video call": "Stäng videosamtal",
+        "Add an emoji": "Lägg till emoji",
+        "Close chat": "Avsluta",
+        "Close": "Avsluta",
+        "Back": "Tillbaka",
+        "How was our customer service?": "<p><strong>Hur lyckades vi att hjälpa dig?</strong></p>",
+        "Next": "Fortsätta"
+      },
+      "welcome": " ",
+      "inQueueText": " ",
+      "noQueuesText": " ",
+      "motd": " "
+    },
+    "responsive": {
+      "closeButton": false,
+      "previewFiles": true,
+      "window": {
+        "promoBubble": {
+          "title": null,
+          "description": null,
+          "image": null
+        }
+      }
+    },
+    "offline": {
+      "window": {
+        "promoBubble": {
+          "title": null,
+          "description": null,
+          "image": null
+        }
+      }
     }
   }

--- a/NinchatSDKSwiftTests/SiteConfigurationTests.swift
+++ b/NinchatSDKSwiftTests/SiteConfigurationTests.swift
@@ -14,7 +14,7 @@ final class SiteConfigurationTests: XCTestCase {
         super.setUp()
 
         do {
-            siteConfiguration = SiteConfigurationImpl(configuration: try openAsset(forResource: "site-configuration-mock"), environments: ["default"])
+            siteConfiguration = SiteConfigurationImpl(configuration: try openAsset(forResource: "site-configuration-mock"), environments: ["fi-restart", "fi"])
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -30,16 +30,20 @@ final class SiteConfigurationTests: XCTestCase {
     }
 
     func test_11_postQuestionnaire_style() {
-        XCTAssertEqual(siteConfiguration?.preAudienceQuestionnaireStyle, .form)
+        XCTAssertEqual(siteConfiguration?.preAudienceQuestionnaireStyle, .conversation)
         XCTAssertEqual(siteConfiguration?.postAudienceQuestionnaireStyle, .conversation)
     }
 
     func test_12_audienceQuestionnaire_name_avatar() {
-        XCTAssertNotNil(siteConfiguration?.audienceQuestionnaireAvatar)
-        XCTAssertTrue(siteConfiguration?.audienceQuestionnaireAvatar as? Bool ?? false)
+        XCTAssertNotNil(siteConfiguration?.audienceQuestionnaireAvatar as? String)
+        XCTAssertEqual(siteConfiguration?.audienceQuestionnaireUserName, "Mielen-botti")
+    }
 
-        XCTAssertNotNil(siteConfiguration?.audienceQuestionnaireUserName)
-        XCTAssertEqual(siteConfiguration?.audienceQuestionnaireUserName, "Ninchat")
+    func test_20_envPriority() {
+        XCTAssertNil(siteConfiguration?.sendButtonTitle, "The key is missing from all given environments + default")
+        XCTAssertEqual(siteConfiguration?.userName, "Asiakas (öäå)", "The key should be read from 'default' since neither 'fi' nor 'fi-restart' contains that.")
+        XCTAssertEqual(siteConfiguration?.audienceRealm, "5lmphjc200m3g", "They key should be read from 'fi-restart' since 'fi' doesn't contain that.")
+        XCTAssertEqual(siteConfiguration?.welcome, "fi", "The key is present in all env, but it should be read from 'fi' according to the reversed sort of the given array")
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ These issues are caused by limitations of the [gomobile bind tool](https://godoc
 
 ## Overriding Image Assets
 
-Using the API delegate method `overrideImageAsset(session:forKey:)` you may supply your own Image assets as `UIImage` objects. See the table below for explanations on the supported asset keys.
+Using the API delegate method `ninchat(session:overrideImageAssetForKey)` you may supply your own Image assets as `UIImage` objects. See the table below for explanations on the supported asset keys.
 
 Note that all the buttons may not be available in the UI.
 
@@ -244,7 +244,7 @@ All the assets should be transparent where there is no color.
 
 ## Overriding Color Assets
 
-Using the API delegate method `overrideColorAsset(session:forKey:)` you may supply your own color assets as `UIColor` objects. See the table below for explanations on the supported asset keys.
+Using the API delegate method `ninchat(session:overrideColorAssetForKey)` you may supply your own color assets as `UIColor` objects. See the table below for explanations on the supported asset keys.
 
 | Asset key       | Related UI control(s)
 |:------------- |:-------------|
@@ -270,9 +270,17 @@ Using the API delegate method `overrideColorAsset(session:forKey:)` you may supp
 | .ratingNeutralText | Text of the neutral rating button
 | .ratingNegativeText | Text of the negative rating button
 
-## Overriding Questionnaire Color Assets
+## Questionnaire
+Starting version [0.3.0](https://github.com/somia/ninchat-sdk-ios-swift/releases/tag/0.3.0), the SDK adds support for configurable questionnaire that are shown before the chat starts and after the chat is finished. Using the following APIs, you can customize how questionnaire looks.
 
-Starting version [0.3.0](https://github.com/somia/ninchat-sdk-ios-swift/releases/tag/0.3.0) supports questionnaire feature before the chat starts and after the chat is finished. Using the API delegate method `ninchat(session:overrideQuestionnaireColorAssetKey)` you may supply your own color assets as `UIColor` objects. See the table below for explanations on the supported asset keys.
+### Overriding Questionnaire Image Assets
+To override questionnaire image assets, you can use the same API as other image assets, i.e. `ninchat(session:overrideImageAssetForKey)` with the following keys:
+| Asset key       | Related UI control(s)           | Notes  |
+|:------------- |:-------------|:-----|
+| .questionnaireBackground | Questionnaire view's repeating texture. | Should be repeatable (tiling). |
+
+### Overriding Questionnaire Color Assets
+Using the API delegate method `ninchat(session:overrideQuestionnaireColorAssetKey)` you may supply your own color assets as `UIColor` objects. See the table below for explanations on the supported asset keys.
 
 | Asset key                    | Related UI control(s)                                        |
 |:---------------------------- |:------------------------------------------------------------ |


### PR DESCRIPTION
- readme: update to include questionnaire image override (#155)
- questionnaire: fix view reset caused by scrolling (#161)
- questionnaire: reset row view on back button tap (#160)
- questionnaire: fix issue with enabled invalid navigation buttons (#159)
- site_config: resolve an issue for overriding null values (#158)
- questionnaire: add more padding for elements' title (#157)
- questionnaire: save answer while user typing with 0.5s delay (#156)
- fix: apply avatar update to loading questionnaire cell (#166)
- fix: lookup issue in some cases (#165)
- fix/video call issue 281 (#167)
- fix a crash caused by loading heavy questionnaires in modal mode (#164)
- Fix/long text questionnaire size issue (#163)
