### PR TITLE
support secure_metadata on resume

### DIFF
--- a/Frameworks/NinchatLowLevelClient.framework/Versions/A/Headers/NINLowLevelClient.objc.h
+++ b/Frameworks/NinchatLowLevelClient.framework/Versions/A/Headers/NINLowLevelClient.objc.h
@@ -151,6 +151,7 @@
 - (NINLowLevelClientObjects* _Nullable)getObjectArray:(NSString* _Nullable)key error:(NSError* _Nullable* _Nullable)error;
 - (NSString* _Nonnull)getString:(NSString* _Nullable)key error:(NSError* _Nullable* _Nullable)error;
 - (NINLowLevelClientStrings* _Nullable)getStringArray:(NSString* _Nullable)key error:(NSError* _Nullable* _Nullable)error;
+- (NSString* _Nonnull)marshalJSON:(NSError* _Nullable* _Nullable)error;
 - (void)setBool:(NSString* _Nullable)key val:(BOOL)val;
 - (void)setFloat:(NSString* _Nullable)key val:(double)val;
 - (void)setInt:(NSString* _Nullable)key val:(long)val;
@@ -159,6 +160,7 @@
 - (void)setString:(NSString* _Nullable)key val:(NSString* _Nullable)val;
 - (void)setStringArray:(NSString* _Nullable)key ref:(NINLowLevelClientStrings* _Nullable)ref;
 - (NSString* _Nonnull)string;
+- (BOOL)unmarshalJSON:(NSString* _Nullable)data error:(NSError* _Nullable* _Nullable)error;
 @end
 
 @interface NINLowLevelClientSession : NSObject <goSeqRefInterface> {

--- a/NinchatLowLevelClient.podspec
+++ b/NinchatLowLevelClient.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "NinchatLowLevelClient"
-  s.version      = "0.2.8"
+  s.version      = "0.3.10"
   s.summary      = "Low-level communications library for Ninchat messaging."
   s.description  = "For providing low-level communications using Ninchat messaging."
   s.homepage     = "https://ninchat.com/"

--- a/NinchatSDKSwift.podspec
+++ b/NinchatSDKSwift.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "NinchatSDKSwift"
-  s.version      = "0.3.0"
+  s.version      = "0.3.10"
   s.summary      = "iOS SDK for Ninchat, Swift version"
   s.description  = "For building iOS applications using Ninchat messaging."
   s.homepage     = "https://ninchat.com/"
@@ -41,7 +41,7 @@ Pod::Spec.new do |s|
   s.dependency "GoogleWebRTC"
   s.dependency 'AnyCodable-FlightSchool', '~> 0.2.3'
   s.dependency "AutoLayoutSwift", "4.0.0"
-  s.dependency "NinchatLowLevelClient", "~> 0.2.8"
+  s.dependency "NinchatLowLevelClient", "~> 0.3.10"
 
   s.module_name = "NinchatSDKSwift"
 end

--- a/NinchatSDKSwift.xcodeproj/project.pbxproj
+++ b/NinchatSDKSwift.xcodeproj/project.pbxproj
@@ -207,6 +207,7 @@
 		91A16FCD03A86BCB1E0FAA74 /* QuestionnaireElementConnectorRedirectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91A16930C7E57664292AC220 /* QuestionnaireElementConnectorRedirectTests.swift */; };
 		9810520368704C8E3C7F2D92 /* Pods_NinchatSDKSwiftServerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6176315081A11762D37BC6C /* Pods_NinchatSDKSwiftServerTests.framework */; };
 		A9AB26D31FF8CC4A41698EB5 /* Pods_NinchatSDKSwiftTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FEAD27BEEC9ED9A48EB128E /* Pods_NinchatSDKSwiftTests.framework */; };
+		B704E3E68829ED0963294E84 /* NSUserDefaults+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B704E5FC177573DF56D2369A /* NSUserDefaults+Extension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -439,6 +440,7 @@
 		91A16F9F20590A73609F0DDB /* UITextField+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITextField+Extension.swift"; sourceTree = "<group>"; };
 		91A16FA13B1F62E386352B88 /* NINSessionCredentials.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NINSessionCredentials.swift; sourceTree = "<group>"; };
 		91A16FEAA858008AD23DF96D /* NinchatSDKSwiftServerMessengerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NinchatSDKSwiftServerMessengerTests.swift; sourceTree = "<group>"; };
+		B704E5FC177573DF56D2369A /* NSUserDefaults+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSUserDefaults+Extension.swift"; sourceTree = "<group>"; };
 		CE774BD7EED85980393E55AF /* Pods-NinchatSDKSwiftTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NinchatSDKSwiftTests.release.xcconfig"; path = "Target Support Files/Pods-NinchatSDKSwiftTests/Pods-NinchatSDKSwiftTests.release.xcconfig"; sourceTree = "<group>"; };
 		D463517AB20A2F6A738E2978 /* Pods-NinchatSDKSwiftUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NinchatSDKSwiftUITests.debug.xcconfig"; path = "Target Support Files/Pods-NinchatSDKSwiftUITests/Pods-NinchatSDKSwiftUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		ED659B1BF359B2E2971FF138 /* Pods-NinchatSDKSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NinchatSDKSwift.debug.xcconfig"; path = "Target Support Files/Pods-NinchatSDKSwift/Pods-NinchatSDKSwift.debug.xcconfig"; sourceTree = "<group>"; };
@@ -696,6 +698,7 @@
 				91A16F9F20590A73609F0DDB /* UITextField+Extension.swift */,
 				91A16739D24E30A3D062D285 /* Array+Extension.swift */,
 				91A16E7CDA2F9D24FF1BE1DC /* Thread+Extension.swift */,
+				B704E5FC177573DF56D2369A /* NSUserDefaults+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1473,6 +1476,7 @@
 				91A1601A6F8D21DA68AC39A6 /* ComposeUIAction.swift in Sources */,
 				91A16813665172FFFA81A455 /* NinchatError.swift in Sources */,
 				91A162DDA99D9DDB9D0B8436 /* Thread+Extension.swift in Sources */,
+				B704E3E68829ED0963294E84 /* NSUserDefaults+Extension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NinchatSDKSwift/Implementations/Extensions/Debugger.swift
+++ b/NinchatSDKSwift/Implementations/Extensions/Debugger.swift
@@ -34,7 +34,7 @@ struct debugger {
             if let queueID = error.queueID, !queueID.isEmpty { log += ",   queue_id: \(queueID)" }
             if let tagID = error.tagID, !tagID.isEmpty { log += ",   tag_id: \(tagID)" }
             if let messageType = error.messageType, !messageType.isEmpty { log += ",   tag_id: \(messageType)" }
-            print(log)
+            debugger(log)
         }
 
         if isDebugOnly {

--- a/NinchatSDKSwift/Implementations/Extensions/NINLowLevelClientProps+Extension.swift
+++ b/NinchatSDKSwift/Implementations/Extensions/NINLowLevelClientProps+Extension.swift
@@ -79,6 +79,7 @@ protocol NINLowLevelSessionProps {
     var name: NINResult<String> { set get }
 
     func setAction(_ action: NINLowLevelClientActions)
+    func setPreAnswers(_ dictionary: [String:AnyHashable])
 }
 
 extension NINLowLevelClientProps: NINLowLevelSessionProps {
@@ -118,6 +119,13 @@ extension NINLowLevelClientProps: NINLowLevelSessionProps {
 
     func setAction(_ action: NINLowLevelClientActions) {
         self.set(value: action.rawValue, forKey: "action")
+    }
+
+    func setPreAnswers(_ dictionary: [String:AnyHashable]) {
+        let metadata = dictionary.reduce(into: NINLowLevelClientProps()) { (metadata: inout NINLowLevelClientProps, tuple: (key: String, value: Any)) in
+            metadata.set(value: tuple.value, forKey: tuple.key)
+        }
+        self.set(value: metadata, forKey: "pre_answers")
     }
 }
 

--- a/NinchatSDKSwift/Implementations/Extensions/NSUserDefaults+Extension.swift
+++ b/NinchatSDKSwift/Implementations/Extensions/NSUserDefaults+Extension.swift
@@ -1,0 +1,26 @@
+//
+// Copyright (c) 10.11.2020 Somia Reality Oy. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+import Foundation
+
+extension UserDefaults {
+    enum Keys: String {
+        case metadata
+    }
+
+    static func save<T:Any>(_ value: T, key: Keys) {
+        UserDefaults.standard.set(value, forKey: key.rawValue)
+        UserDefaults.standard.synchronize()
+    }
+
+    static func load<T:Any>(forKey key: Keys) -> T? {
+        UserDefaults.standard.value(forKey: key.rawValue) as? T
+    }
+
+    static func remove(forKey key: Keys) {
+        UserDefaults.standard.removeObject(forKey: key.rawValue)
+    }
+}

--- a/NinchatSDKSwift/Implementations/Managers/NINChatSession Internal/NINChatSessionInternal.swift
+++ b/NinchatSDKSwift/Implementations/Managers/NINChatSession Internal/NINChatSessionInternal.swift
@@ -48,6 +48,10 @@ struct InternalDelegate: NINChatSessionInternalDelegate {
     }
     
     internal func onDidEnd() {
+        /// According to https://github.com/somia/mobile/issues/287
+        /// Clear metadata from the UserDefaults on a normal close
+        UserDefaults.remove(forKey: .metadata)
+
         DispatchQueue.main.async {
             guard let session = self.session else { return }
             session.delegate?.ninchatDidEnd(session)

--- a/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSessionManagerImpl.swift
+++ b/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSessionManagerImpl.swift
@@ -273,6 +273,10 @@ extension NINChatSessionManagerImpl {
         func performJoin() throws {
             delegate?.log(value: "Joining queue \(ID)..")
             self.onChannelJoined = {
+                /// According to https://github.com/somia/mobile/issues/287
+                /// Clear metadata from the UserDefaults on a successful join
+                UserDefaults.remove(forKey: .metadata)
+
                 completion()
             }
             

--- a/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSessionManagerImpl.swift
+++ b/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSessionManagerImpl.swift
@@ -123,12 +123,15 @@ final class NINChatSessionManagerImpl: NSObject, NINChatSessionManager, NINChatD
     var givenConfiguration: NINSiteConfiguration?
     var preAudienceQuestionnaireMetadata: NINLowLevelClientProps! {
         didSet {
-            if let audienceMetadata = self.audienceMetadata {
-                audienceMetadata.set(value: preAudienceQuestionnaireMetadata, forKey: "pre_answers")
+            /// Since metadata is loaded from the UserDefaults instead of memory,
+            /// it is necessary to update its value after pre_answers are set
+            var metadata = self.audienceMetadata
+            if metadata != nil {
+                metadata!.set(value: preAudienceQuestionnaireMetadata, forKey: "pre_answers")
             } else {
-                self.audienceMetadata = NINLowLevelClientProps.initiate(metadata: ["pre_answers": preAudienceQuestionnaireMetadata])
+                metadata = NINLowLevelClientProps.initiate(metadata: ["pre_answers": preAudienceQuestionnaireMetadata])
             }
-
+            self.audienceMetadata = metadata
         }
     }
     var appDetails: String?

--- a/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSessionManagerImpl.swift
+++ b/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSessionManagerImpl.swift
@@ -92,8 +92,8 @@ final class NINChatSessionManagerImpl: NSObject, NINChatSessionManager, NINChatD
         set {
             /// If given metadata is not null, it is saved in the UserDefaults
             autoreleasepool {
-                var error: NSErrorPointer = nil
-                if let audienceMetadataJSON = newValue?.marshalJSON(error), error == nil {
+                var error: NSError?
+                if let audienceMetadataJSON = newValue?.marshalJSON(&error), error == nil {
                     UserDefaults.save(audienceMetadataJSON, key: .metadata)
                 }
             }

--- a/NinchatSDKSwift/Implementations/View Model/NINQuestionnaireViewModel.swift
+++ b/NinchatSDKSwift/Implementations/View Model/NINQuestionnaireViewModel.swift
@@ -21,7 +21,7 @@ protocol NINQuestionnaireViewModel {
     var onSessionFinished: (() -> Void)? { get set }
     var requirementSatisfactionUpdater: ((Bool) -> Void)? { get set }
 
-    init(sessionManager: NINChatSessionManager?, questionnaireType: AudienceQuestionnaireType)
+    init(sessionManager: NINChatSessionManager?, audienceMetadata: NINLowLevelClientProps?, questionnaireType: AudienceQuestionnaireType)
     func isExitElement(_ element: Any?) -> Bool
     func getConfiguration() throws -> QuestionnaireConfiguration
     func getElements() throws -> [QuestionnaireElement]
@@ -59,8 +59,9 @@ final class NINQuestionnaireViewModelImpl: NINQuestionnaireViewModel {
     private var configurations: [QuestionnaireConfiguration] = []
     internal var connector: QuestionnaireElementConnector!
     private var views: [[QuestionnaireElement]] = []
-    internal var answers: [String:AnyHashable]! = [:]    // Contains answers saved by the user in the runtime
-    internal var preAnswers: [String:AnyHashable]! = [:] // Contains answers already given by the server
+    internal var answers: [String:AnyHashable]! = [:]    // Holds answers saved by the user in the runtime
+    internal var preAnswers: [String:AnyHashable]! = [:] // Holds answers already given by the server
+    internal var audienceMetadata: NINLowLevelClientProps? // Holds given metadata during the initialization
     private var setPageNumber: Int?
     private var setupConnectorOperation: BlockOperation!
     
@@ -85,8 +86,9 @@ final class NINQuestionnaireViewModelImpl: NINQuestionnaireViewModel {
     var onQuestionnaireFinished: ((Queue?, _ exit: Bool) -> Void)?
     var requirementSatisfactionUpdater: ((Bool) -> Void)?
 
-    init(sessionManager: NINChatSessionManager?, questionnaireType: AudienceQuestionnaireType) {
+    init(sessionManager: NINChatSessionManager?, audienceMetadata: NINLowLevelClientProps?, questionnaireType: AudienceQuestionnaireType) {
         self.sessionManager = sessionManager
+        self.audienceMetadata = audienceMetadata
 
         let configurationOperation = BlockOperation { [weak self] in
             guard let configurations = (questionnaireType == .pre) ? sessionManager?.siteConfiguration.preAudienceQuestionnaire : sessionManager?.siteConfiguration.postAudienceQuestionnaire else { return }
@@ -201,7 +203,13 @@ final class NINQuestionnaireViewModelImpl: NINQuestionnaireViewModel {
 
     private func registerAudience(queueID: String, completion: @escaping (Error?) -> Void) {
         do {
-            try self.sessionManager?.registerQuestionnaire(queue: queueID, answers: NINLowLevelClientProps.initiate(preQuestionnaireAnswers: self.answers), completion: completion)
+            if let audienceMetadata = self.audienceMetadata {
+                audienceMetadata.setPreAnswers(self.answers)
+            } else {
+                audienceMetadata = NINLowLevelClientProps.initiate(preQuestionnaireAnswers: self.answers)
+            }
+
+            try self.sessionManager?.registerQuestionnaire(queue: queueID, answers: audienceMetadata!, completion: completion)
         } catch {
             completion(error)
         }

--- a/NinchatSDKSwift/Implementations/View Model/NINQuestionnaireViewModel.swift
+++ b/NinchatSDKSwift/Implementations/View Model/NINQuestionnaireViewModel.swift
@@ -203,13 +203,10 @@ final class NINQuestionnaireViewModelImpl: NINQuestionnaireViewModel {
 
     private func registerAudience(queueID: String, completion: @escaping (Error?) -> Void) {
         do {
-            if let audienceMetadata = self.audienceMetadata {
-                audienceMetadata.setPreAnswers(self.answers)
-            } else {
-                audienceMetadata = NINLowLevelClientProps.initiate(preQuestionnaireAnswers: self.answers)
-            }
-
-            try self.sessionManager?.registerQuestionnaire(queue: queueID, answers: audienceMetadata!, completion: completion)
+            let metadata = self.audienceMetadata ?? NINLowLevelClientProps()
+            metadata.set(value: questionnaireAnswers, forKey: "pre_answers")
+            
+            try self.sessionManager?.registerQuestionnaire(queue: queueID, answers: metadata, completion: completion)
         } catch {
             completion(error)
         }

--- a/NinchatSDKSwift/NINChatSession.swift
+++ b/NinchatSDKSwift/NINChatSession.swift
@@ -60,9 +60,9 @@ public final class NINChatSession: NINChatSessionProtocol, NINChatDevHelper {
             return Constants.kProductionServerAddress.rawValue
         #endif
     }
-    
+
     // MARK: - NINChatDevHelper
-    
+
     public var serverAddress: String! {
         set { self.sessionManager.serverAddress = newValue }
         get { self.sessionManager.serverAddress }
@@ -73,7 +73,7 @@ public final class NINChatSession: NINChatSessionProtocol, NINChatDevHelper {
     }
 
     // MARK: - NINChatSessionProtocol
-    
+
     public weak var delegate: NINChatSessionDelegate?
     public var session: NINResult<NINLowLevelClientSession?> {
         guard self.started else { return .failure(NINExceptions.apiNotStarted) }
@@ -128,12 +128,12 @@ public final class NINChatSession: NINChatSessionProtocol, NINChatDevHelper {
                     do {
                         try self?.openChatSession(credentials: credentials) { credentials, error in
                             guard let weakSelf = self, error == nil else { completion(credentials, error); return }
-                            
+
                             /// Prepare coordinator for starting
                             /// This is quire important to prepare time and memory consuming tasks before the user
                             /// starts the coordinator, otherwise he/she will face unexpected views
                             if weakSelf.coordinator == nil { weakSelf.coordinator = NINCoordinator(with: weakSelf) }
-                            weakSelf.coordinator?.prepareNINQuestionnaireViewModel {
+                            weakSelf.coordinator?.prepareNINQuestionnaireViewModel(audienceMetadata: weakSelf.audienceMetadata) {
                                 completion(credentials, error)
                             }
                         }
@@ -162,7 +162,7 @@ public final class NINChatSession: NINChatSessionProtocol, NINChatDevHelper {
         self.sessionManager = nil
         self.started = false
         self.sessionAlive = false
-        
+
         self.internalDelegate?.onDidEnd()
     }
 }
@@ -196,7 +196,7 @@ extension NINChatSession {
         guard Thread.isMainThread else { throw NINExceptions.mainThread }
         try sessionManager.openSession { [weak self] credentials, canResume, error in
             guard error == nil else { completion(credentials, error); return }
-            
+
             do {
                 /// Find our realm's queues
                 /// Potentially passing a nil queueIds here is intended

--- a/NinchatSDKSwift/NINChatSession.swift
+++ b/NinchatSDKSwift/NINChatSession.swift
@@ -162,6 +162,8 @@ public final class NINChatSession: NINChatSessionProtocol, NINChatDevHelper {
         self.sessionManager = nil
         self.started = false
         self.sessionAlive = false
+        
+        self.internalDelegate?.onDidEnd()
     }
 }
 

--- a/NinchatSDKSwiftServerTests/NinchatSDKSwiftAcceptanceTests.swift
+++ b/NinchatSDKSwiftServerTests/NinchatSDKSwiftAcceptanceTests.swift
@@ -389,7 +389,7 @@ extension NinchatSDKSwiftAcceptanceTests {
                     XCTAssertNil(error)
                     XCTAssertNotNil(stunServers)
                     XCTAssertNotNil(turnServers)
-                    self.rtcClient = NINChatWebRTCClientImpl(sessionManager: self.sessionManager, operatingMode: .callee, stunServers: stunServers, turnServers: turnServers, delegate: self)
+                    self.rtcClient = NINChatWebRTCClientImpl(sessionManager: self.sessionManager, operatingMode: .callee, stunServers: stunServers, turnServers: turnServers, candidates: [], delegate: self)
 
                     do {
                         try self.rtcClient?.start(with: signal)

--- a/NinchatSDKSwiftTests/CoordinatorTests.swift
+++ b/NinchatSDKSwiftTests/CoordinatorTests.swift
@@ -14,7 +14,7 @@ class CoordinatorTests: XCTestCase {
     
 
     override func setUp() {
-        coordinator = NINCoordinator(with: session, audienceMetadata: nil)
+        coordinator = NINCoordinator(with: session)
     }
 
     override func tearDown() { }

--- a/NinchatSDKSwiftTests/CoordinatorTests.swift
+++ b/NinchatSDKSwiftTests/CoordinatorTests.swift
@@ -14,7 +14,7 @@ class CoordinatorTests: XCTestCase {
     
 
     override func setUp() {
-        coordinator = NINCoordinator(with: session)
+        coordinator = NINCoordinator(with: session, audienceMetadata: nil)
     }
 
     override func tearDown() { }

--- a/NinchatSDKSwiftTests/NINLowLevelClientPropsTests.swift
+++ b/NinchatSDKSwiftTests/NINLowLevelClientPropsTests.swift
@@ -59,6 +59,20 @@ final class NINLowLevelClientPropsTests: XCTestCase {
         XCTAssertEqual(value6.value, 6.8)
     }
 
+    func test_initializer_nested_dictionary() {
+        let level1 = NINLowLevelClientProps.initiate(metadata: ["secure-key": "secure-value"])
+        XCTAssertNotNil(level1)
+        XCTAssertEqual(level1.getString("secure-key", error: nil), "secure-value")
+
+        let level2 = NINLowLevelClientProps.initiate(metadata: ["normal-key": "normal-value", "secure-dic": level1])
+        XCTAssertNotNil(level2)
+        XCTAssertEqual(level2.getString("normal-key", error: nil), "normal-value")
+
+        XCTAssertNoThrow(try level2.getObject("secure-dic"))
+        let secureDic = try! level2.getObject("secure-dic")
+        XCTAssertEqual(secureDic.getString("secure-key", error: nil), "secure-value")
+    }
+
     func test_initializer_preQuestionnaire() {
         let answers: [String:AnyHashable] = ["Koronavirus-jatko": "Näytä muut aiheet", "language": "English", "number-of-messages": 3.2]
         let props = NINLowLevelClientProps.initiate(preQuestionnaireAnswers: answers)

--- a/NinchatSDKSwiftTests/NINQuestionnaireViewModelTests.swift
+++ b/NinchatSDKSwiftTests/NINQuestionnaireViewModelTests.swift
@@ -20,7 +20,7 @@ final class NINQuestionnaireViewModelTests: XCTestCase {
         return sessionManager
     }()
     private lazy var viewModel: NINQuestionnaireViewModelImpl? = {
-        let viewModel = NINQuestionnaireViewModelImpl(sessionManager: session, questionnaireType: .pre)
+        let viewModel = NINQuestionnaireViewModelImpl(sessionManager: session, audienceMetadata: nil, questionnaireType: .pre)
         viewModel.queue = Queue(queueID: "", name: "", isClosed: false, permissions: QueuePermissions(upload: false))
         
         let expect = self.expectation(description: "Expected to initiate the view model")

--- a/NinchatSDKSwiftTests/QuestionnaireDataSourceDelegateTests.swift
+++ b/NinchatSDKSwiftTests/QuestionnaireDataSourceDelegateTests.swift
@@ -19,7 +19,7 @@ final class QuestionnaireDataSourceDelegateTests: XCTestCase {
         return session
     }()
     private lazy var viewModel: NINQuestionnaireViewModel! = {
-        let viewModel = NINQuestionnaireViewModelImpl(sessionManager: self.session.sessionManager, questionnaireType: .pre)
+        let viewModel = NINQuestionnaireViewModelImpl(sessionManager: self.session.sessionManager, audienceMetadata: nil, questionnaireType: .pre)
         viewModel.queue = Queue(queueID: "", name: "", isClosed: false, permissions: QueuePermissions(upload: false))
         
         let expect = self.expectation(description: "Expected to initiate the view model")

--- a/Podfile
+++ b/Podfile
@@ -8,7 +8,7 @@ source 'https://github.com/somia/ninchat-podspecs.git'
 def libraries
   pod 'AnyCodable-FlightSchool', '~> 0.2.3'
   pod 'AutoLayoutSwift', '4.0.0'
-  pod 'NinchatLowLevelClient', '~> 0.2.8'
+  pod 'NinchatLowLevelClient', '~> 0.3.10'
   pod 'GoogleWebRTC'
 end
 


### PR DESCRIPTION
The PR uses a new version of LowLevelClient (0.3.10) which would be available once SwiftSDK 0.3.10 is release. This results in a deadlock situation for CI tests, and thus, tests must be ignored for this PR.

fixes somia/mobile#287

### Update
To test the PR, change your Podfile as below:

```ruby
  pod 'NinchatSDKSwift', :git => 'https://github.com/somia/ninchat-sdk-ios-swift.git', :branch => 'feature/secure_metadata-287'
  pod 'NinchatLowLevelClient', :git => 'https://github.com/somia/ninchat-sdk-ios-swift.git', :branch => 'feature/secure_metadata-287'
```
