### PR TITLE
UserDefaults: migrate from ‘standard’ to ‘ninchat’ suite

### DIFF
--- a/NinchatSDKSwift/Implementations/Extensions/NSUserDefaults+Extension.swift
+++ b/NinchatSDKSwift/Implementations/Extensions/NSUserDefaults+Extension.swift
@@ -10,17 +10,33 @@ extension UserDefaults {
     enum Keys: String {
         case metadata
     }
-
+    
+    static var ninchat: UserDefaults {
+        UserDefaults(suiteName: "com.ninchat.sdk.swift")!
+    }
+    
     static func save<T:Any>(_ value: T, key: Keys) {
-        UserDefaults.standard.set(value, forKey: key.rawValue)
-        UserDefaults.standard.synchronize()
+        UserDefaults.ninchat.set(value, forKey: key.rawValue)
+        UserDefaults.ninchat.synchronize()
     }
 
     static func load<T:Any>(forKey key: Keys) -> T? {
-        UserDefaults.standard.value(forKey: key.rawValue) as? T
+        migrate(key: key)
+        return UserDefaults.ninchat.value(forKey: key.rawValue) as? T
     }
 
     static func remove(forKey key: Keys) {
+        UserDefaults.ninchat.removeObject(forKey: key.rawValue)
+    }
+    
+    // MARK: - Helper
+    
+    /// migrate value from 'standard' to 'ninchat'
+    private static func migrate(key: Keys) {
+        let value = UserDefaults.standard.value(forKey: key.rawValue)
+        if value == nil { return }
+        
+        self.save(value, key: key)
         UserDefaults.standard.removeObject(forKey: key.rawValue)
     }
 }


### PR DESCRIPTION
When using `UserDefaults.standard`, the host app can read/write the metadata outside of the SDK. This can result in unexpected behaviours in some cases. With this commit, the SDK creates a separate suite to save and load metadata there.
The host app still **can override** the metadata, but it needs to explicitly access to the suite.
