### PR TITLE
UIImageView+Extension: improve performance

### DIFF
--- a/NinchatSDKSwift/Implementations/Extensions/UIImageView+Extension.swift
+++ b/NinchatSDKSwift/Implementations/Extensions/UIImageView+Extension.swift
@@ -4,33 +4,34 @@
 // license that can be found in the LICENSE file.
 //
 
+import Foundation
 import UIKit
 
 extension UIImageView {
-    func image(from url: String?, completion: ((Data) -> Void)? = nil) {
+    func image(from url: String?, aspectRatio: CGFloat = 1, completion: ((Data) -> Void)? = nil) {
         guard let urlStr = url  else { return }
-        self.image(from: URL(string: urlStr), completion: completion)
+        self.image(from: URL(string: urlStr), aspectRatio: aspectRatio, completion: completion)
     }
     
-    func image(from url: URL?, completion: ((Data) -> Void)? = nil) {
+    func image(from url: URL?, aspectRatio: CGFloat = 1, completion: ((Data) -> Void)? = nil) {
         guard let url = url else { return }
     
         URLSession.shared.dataTask(with: URLRequest(url: url, cachePolicy: .returnCacheDataElseLoad)) { (data: Data?, response: URLResponse?, error: Error?) in
             guard
                 let httpURLResponse = response as? HTTPURLResponse, httpURLResponse.statusCode == 200,
                 let mimeType = response?.mimeType, mimeType.hasPrefix("image"),
-                let data = data, error == nil,
-                let image = UIImage(data: data)
+                let data = data, error == nil
             else { return }
         
-            DispatchQueue.main.async() {
+            DispatchQueue.main.async() { [weak self] in
+                guard let `self` = self, let image = data.downsample(view: self, aspectRatio: aspectRatio) ?? UIImage(data: data) else { return }
                 self.image = image
                 completion?(data)
             }
         }.resume()
     }
 
-    func fetchImage(from url: URL?, completion: ((Data) -> Void)? = nil) {
+    func fetchImage(from url: URL?, aspectRatio: CGFloat = 1, completion: ((UIImage, UIImage) -> Void)? = nil) {
         guard let url = url else { return }
         URLSession.shared.dataTask(with: URLRequest(url: url, cachePolicy: .returnCacheDataElseLoad)) { (data: Data?, response: URLResponse?, error: Error?) in
             guard
@@ -39,7 +40,10 @@ extension UIImageView {
                 let data = data, error == nil
             else { return }
 
-            DispatchQueue.main.async() { completion?(data) }
+            DispatchQueue.main.async() { [weak self] in
+                guard let `self` = self, let image = UIImage(data: data), let thumbnail = data.downsample(view: self, aspectRatio: aspectRatio) else { return }
+                completion?(image, thumbnail)
+            }
         }.resume()
     }
 
@@ -51,5 +55,29 @@ extension UIImageView {
         get {
             self.tintColor
         }
+    }
+}
+
+extension Data {
+    /// inspired from the article  https://swiftsenpai.com/development/reduce-uiimage-memory-footprint/
+    
+    fileprivate func downsample(view: UIView, aspectRatio: CGFloat) -> UIImage? {
+        // Create an CGImageSource that represent an image
+        guard let imageSource = CGImageSourceCreateWithData(self as CFData, [kCGImageSourceShouldCache: false] as CFDictionary) else { return nil }
+                
+        // Perform downsampling
+        let downsampleOptions = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: Swift.max(view.width?.constant ?? view.bounds.width, view.height?.constant ?? view.bounds.height) * aspectRatio // Calculate the desired dimension
+        ] as CFDictionary
+        
+        guard let downsampledImage = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, downsampleOptions) else {
+            return nil
+        }
+        
+        // Return the downsampled image as UIImage
+        return UIImage(cgImage: downsampledImage)
     }
 }

--- a/NinchatSDKSwift/Implementations/Extensions/UIImageView+Extension.swift
+++ b/NinchatSDKSwift/Implementations/Extensions/UIImageView+Extension.swift
@@ -63,7 +63,7 @@ extension Data {
     
     fileprivate func downsample(view: UIView, aspectRatio: CGFloat) -> UIImage? {
         // Create an CGImageSource that represent an image
-        guard let imageSource = CGImageSourceCreateWithData(self as CFData, [kCGImageSourceShouldCache: false] as CFDictionary) else { return nil }
+        guard let imageSource = CGImageSourceCreateWithData(self as CFData, [kCGImageSourceShouldCache: true] as CFDictionary) else { return nil }
                 
         // Perform downsampling
         let downsampleOptions = [

--- a/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Channel Cell/ChatChannelMediaCell.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Channel Cell/ChatChannelMediaCell.swift
@@ -133,7 +133,7 @@ extension ChannelMediaCell where Self:ChatChannelCell {
 
 final class ChatChannelMediaMineCell: ChatChannelMineCell, ChannelMediaCell, ChannelMediaCellDelegate {
     var cachedImage: [String:UIImage]? = [:]
-    var originalImage: UIImage?
+    weak var originalImage: UIImage?
     @IBOutlet weak var parentView: UIView!
     @IBOutlet weak var messageImageViewContainer: UIView! {
         didSet {
@@ -187,7 +187,7 @@ final class ChatChannelMediaMineCell: ChatChannelMineCell, ChannelMediaCell, Cha
 
 final class ChatChannelMediaOthersCell: ChatChannelOthersCell, ChannelMediaCell, ChannelMediaCellDelegate {
     var cachedImage: [String:UIImage]? = [:]
-    var originalImage: UIImage?
+    weak var originalImage: UIImage?
     @IBOutlet weak var parentView: UIView!
     @IBOutlet weak var messageImageViewContainer: UIView! {
         didSet {


### PR DESCRIPTION
Inspired by the [article](https://swiftsenpai.com/development/reduce-uiimage-memory-footprint/), the PR reduces the memory consumption by 50%-70% when an attachment is received. The PR simply generates a lightweight thumbnail for the chat page and keeps the original one in case the user wants to open the image in full-screen.

According to attached statistics, for a conversation with 4k images and one video file, the new approach used ~38 MB compared to ~98 MB in the current released version.


![Normal Performance](https://user-images.githubusercontent.com/11143939/100871463-01d84480-34a9-11eb-974c-15f3d281a4ab.png)
![Improve Performance](https://user-images.githubusercontent.com/11143939/100872738-f128ce00-34aa-11eb-965b-71074ecd6ded.png)