### PR TITLE
NINChatSession: fix null coordinator for non-resume

### DIFF
--- a/NinchatSDKSwift.podspec
+++ b/NinchatSDKSwift.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "NinchatSDKSwift"
-  s.version      = "0.3.10"
+  s.version      = "0.3.12"
   s.summary      = "iOS SDK for Ninchat, Swift version"
   s.description  = "For building iOS applications using Ninchat messaging."
   s.homepage     = "https://ninchat.com/"


### PR DESCRIPTION
In case the app doesn’t want to resume, the SDK results in a null `coordinator` instance.
