### PR TITLE
bump to version 0.3.12

### DIFF
--- a/.github/workflows/swift-sdk.yml
+++ b/.github/workflows/swift-sdk.yml
@@ -30,7 +30,7 @@ jobs:
               run: xcodebuild clean
 
             - name: Build SDK
-              run: xcodebuild -workspace NinchatSDKSwift.xcworkspace -scheme NinchatSDKSwift -configuration "Release" -destination "platform=iOS Simulator,name=iPhone 8" "OTHER_LDFLAGS=\$(OTHER_LDFLAGS) -read_only_relocs suppress" CODE_SIGNING_ALLOWED=NO 
+              run: xcodebuild -workspace NinchatSDKSwift.xcworkspace -scheme NinchatSDKSwift -configuration "Release" -destination "platform=iOS Simulator,name=iPhone 8" "OTHER_LDFLAGS=\$(OTHER_LDFLAGS) -read_only_relocs suppress" CODE_SIGNING_ALLOWED=NO ONLY_ACTIVE_ARCH=YES
             
             - name: Run SDK Tests
-              run: xcodebuild test -workspace NinchatSDKSwift.xcworkspace -scheme NinchatSDKSwift -destination "platform=iOS Simulator,name=iPhone 8" "OTHER_LDFLAGS=\$(OTHER_LDFLAGS) -read_only_relocs suppress"
+              run: xcodebuild test -workspace NinchatSDKSwift.xcworkspace -scheme NinchatSDKSwift -destination "platform=iOS Simulator,name=iPhone 8" "OTHER_LDFLAGS=\$(OTHER_LDFLAGS) -read_only_relocs suppress" ONLY_ACTIVE_ARCH=YES

--- a/NinchatSDKSwift.podspec
+++ b/NinchatSDKSwift.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "NinchatSDKSwift"
-  s.version      = "0.3.10"
+  s.version      = "0.3.12"
   s.summary      = "iOS SDK for Ninchat, Swift version"
   s.description  = "For building iOS applications using Ninchat messaging."
   s.homepage     = "https://ninchat.com/"

--- a/NinchatSDKSwift.xcodeproj/project.pbxproj
+++ b/NinchatSDKSwift.xcodeproj/project.pbxproj
@@ -1760,7 +1760,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 0.1;
-				ONLY_ACTIVE_ARCH = YES;
+				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/NinchatSDKSwift/Implementations/Extensions/NSUserDefaults+Extension.swift
+++ b/NinchatSDKSwift/Implementations/Extensions/NSUserDefaults+Extension.swift
@@ -10,17 +10,33 @@ extension UserDefaults {
     enum Keys: String {
         case metadata
     }
-
+    
+    static var ninchat: UserDefaults {
+        UserDefaults(suiteName: "com.ninchat.sdk.swift")!
+    }
+    
     static func save<T:Any>(_ value: T, key: Keys) {
-        UserDefaults.standard.set(value, forKey: key.rawValue)
-        UserDefaults.standard.synchronize()
+        UserDefaults.ninchat.set(value, forKey: key.rawValue)
+        UserDefaults.ninchat.synchronize()
     }
 
     static func load<T:Any>(forKey key: Keys) -> T? {
-        UserDefaults.standard.value(forKey: key.rawValue) as? T
+        migrate(key: key)
+        return UserDefaults.ninchat.value(forKey: key.rawValue) as? T
     }
 
     static func remove(forKey key: Keys) {
+        UserDefaults.ninchat.removeObject(forKey: key.rawValue)
+    }
+    
+    // MARK: - Helper
+    
+    /// migrate value from 'standard' to 'ninchat'
+    private static func migrate(key: Keys) {
+        let value = UserDefaults.standard.value(forKey: key.rawValue)
+        if value == nil { return }
+        
+        self.save(value, key: key)
         UserDefaults.standard.removeObject(forKey: key.rawValue)
     }
 }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Channel Cell/ChatChannelMediaCell.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Channel Cell/ChatChannelMediaCell.swift
@@ -90,23 +90,28 @@ extension ChannelMediaCell where Self:ChatChannelCell {
             }
         }
 
-        if let image = image {
-            self.messageImageView.image = image
-            (self as? ChannelMediaCellDelegate)?.didLoadAttachment(image)
-            updateView()
-        }
-        /// Load the image from cache first
-        else if let id = self.message?.messageID, let image = self.cachedImage?[id] {
-            self.messageImageView.image = image
-            updateView()
-        }
-        /// Load the image in message image view over HTTP or from local cache
-        else if let imageURL = imageURL {
-            self.messageImageView.fetchImage(from: URL(string: imageURL)) { [weak self, message = self.message] data in
-                if self?.message?.messageID != message?.messageID { debugger("** ** Dismiss unrelated attachment"); return }
-                self?.messageImageView.image = UIImage(data: data)
-                (self as? ChannelMediaCellDelegate)?.didLoadAttachment(UIImage(data: data))
+        DispatchQueue.main.async {
+            if let image = image {
+                self.messageImageView.image = image
+                (self as? ChannelMediaCellDelegate)?.didLoadAttachment(image)
+                 updateView()
+            }
+            /// Load the image from cache first
+            else if let id = self.message?.messageID, let image = self.cachedImage?[id] {
+                self.messageImageView.image = image
                 updateView()
+            }
+            /// Load the image in message image view over HTTP or from local cache
+            else if let imageURL = imageURL {
+                self.messageImageView.fetchImage(from: URL(string: imageURL)) { [weak self, message = self.message] data in
+                    DispatchQueue.main.async {
+                        if self?.message?.messageID != message?.messageID { debugger("** ** Dismiss unrelated attachment"); return }
+                        self?.messageImageView.image = UIImage(data: data)
+
+                        (self as? ChannelMediaCellDelegate)?.didLoadAttachment(UIImage(data: data))
+                        updateView()
+                    }
+                }
             }
         }
     }

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINQuestionnaireViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINQuestionnaireViewController.swift
@@ -148,6 +148,8 @@ final class NINQuestionnaireViewController: UIViewController, ViewController, Ke
         /// let elements be loaded for a few seconds
         if self.style == .form { self.initiateFormContentView(0.5) }
         else if self.style == .conversation { self.initiateConversationContentView(1.0) }
+
+        NotificationCenter.default.addObserver(self, selector: #selector(didEnterBackground(notification:)), name: UIApplication.didEnterBackgroundNotification, object: nil)
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -165,6 +167,8 @@ final class NINQuestionnaireViewController: UIViewController, ViewController, Ke
         self.operationQueue.cancelAllOperations()
         self.removeKeyboardListeners()
         self.contentView = nil
+
+        NotificationCenter.default.removeObserver(self, name: UIApplication.didEnterBackgroundNotification, object: nil)
     }
 
     private func overrideAssets() {
@@ -202,6 +206,8 @@ final class NINQuestionnaireViewController: UIViewController, ViewController, Ke
 // MARK: - 'Form Like' questionnaires
 extension NINQuestionnaireViewController: QuestionnaireFormViewController {
     func updateFormContentView(_ interval: TimeInterval = 0.0) {
+        self.view.endEditing(true)
+        
         self.loadingIndicator.startAnimating()
         contentView?.hide(true, andCompletion: { [weak self] in
             self?.contentView?.removeFromSuperview()
@@ -231,6 +237,8 @@ extension NINQuestionnaireViewController: QuestionnaireFormViewController {
 // MARK: - 'Conversation Like' questionnaires
 extension NINQuestionnaireViewController: QuestionnaireConversationController {
     func updateConversationContentView(_ interval: TimeInterval = 0.0) {
+        self.view.endEditing(true)
+
         var newSection = -1
         let prepareOperation = BlockOperation {
             newSection = self.prepareSection()
@@ -337,5 +345,12 @@ extension NINQuestionnaireViewController: UITableViewDataSource, UITableViewDele
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         self.dataSourceDelegate!.cell(at: indexPath, view: self.contentView!)
+    }
+}
+
+extension NINQuestionnaireViewController {
+    @objc
+    private func didEnterBackground(notification: Notification) {
+        self.view.endEditing(true)
     }
 }

--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ try self.ninchatSession.start(credentials: credentials) { (credentials: NINSessi
 
 ##### Resume support for audience metadata
 
-Starting version [0.3.10](https://github.com/somia/ninchat-sdk-ios-swift/releases/tag/0.3.10), the SDK can save and retrive audience metadata directly from the local storage. This makes a host application able to be _resumed_ even if the metadata are not explicitly set. **Please note the SDK raises error if the metadata contains an invalid secure token.** Ensure you catch errors as described in [Catch errors](#catch-errors).
+Starting version [0.3.10](https://github.com/somia/ninchat-sdk-ios-swift/releases/tag/0.3.10), the SDK can save and retrive audience metadata directly from the local storage. This makes a host application able to be *resumed* even if the metadata are not explicitly set. The SDK creates a `UserDefaults` suite with the name `com.ninchat.sdk.swift` to cache the metadata, **so please be aware to not accidentally override the metadata**. 
+
+**Additionally note that the SDK raises error if the metadata contains an invalid secure token.** Ensure you catch errors as described in [Catch errors](https://github.com/somia/ninchat-sdk-ios-swift#catch-errors).
 
 #### Showing the SDK UI
 


### PR DESCRIPTION
- ChatChannelCell: fix crash for background attachment constraint update (#192)
- UserDefaults: migrate from ‘standard’ to ‘ninchat’ suite (#193)
- readme: add metadata suite to avoid accidental override (#194)
- fix/release build failure (#195)
- fix/questionnaire keyboard dismiss (#197)
- NINChatSession: fix null coordinator for non-resume (#199)
