### PR TITLE
refactor/improve attachment performance 294

### DIFF
--- a/NinchatSDKSwift.xcodeproj/project.pbxproj
+++ b/NinchatSDKSwift.xcodeproj/project.pbxproj
@@ -208,6 +208,7 @@
 		9810520368704C8E3C7F2D92 /* Pods_NinchatSDKSwiftServerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6176315081A11762D37BC6C /* Pods_NinchatSDKSwiftServerTests.framework */; };
 		A9AB26D31FF8CC4A41698EB5 /* Pods_NinchatSDKSwiftTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FEAD27BEEC9ED9A48EB128E /* Pods_NinchatSDKSwiftTests.framework */; };
 		B704E3E68829ED0963294E84 /* NSUserDefaults+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B704E5FC177573DF56D2369A /* NSUserDefaults+Extension.swift */; };
+		B704E8410F0ECA2A17505879 /* URL+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B704E5C0EFFB626F12366601 /* URL+Extension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -440,6 +441,7 @@
 		91A16F9F20590A73609F0DDB /* UITextField+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITextField+Extension.swift"; sourceTree = "<group>"; };
 		91A16FA13B1F62E386352B88 /* NINSessionCredentials.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NINSessionCredentials.swift; sourceTree = "<group>"; };
 		91A16FEAA858008AD23DF96D /* NinchatSDKSwiftServerMessengerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NinchatSDKSwiftServerMessengerTests.swift; sourceTree = "<group>"; };
+		B704E5C0EFFB626F12366601 /* URL+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URL+Extension.swift"; sourceTree = "<group>"; };
 		B704E5FC177573DF56D2369A /* NSUserDefaults+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSUserDefaults+Extension.swift"; sourceTree = "<group>"; };
 		CE774BD7EED85980393E55AF /* Pods-NinchatSDKSwiftTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NinchatSDKSwiftTests.release.xcconfig"; path = "Target Support Files/Pods-NinchatSDKSwiftTests/Pods-NinchatSDKSwiftTests.release.xcconfig"; sourceTree = "<group>"; };
 		D463517AB20A2F6A738E2978 /* Pods-NinchatSDKSwiftUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NinchatSDKSwiftUITests.debug.xcconfig"; path = "Target Support Files/Pods-NinchatSDKSwiftUITests/Pods-NinchatSDKSwiftUITests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -700,6 +702,7 @@
 				91A16739D24E30A3D062D285 /* Array+Extension.swift */,
 				91A16E7CDA2F9D24FF1BE1DC /* Thread+Extension.swift */,
 				B704E5FC177573DF56D2369A /* NSUserDefaults+Extension.swift */,
+				B704E5C0EFFB626F12366601 /* URL+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1477,6 +1480,7 @@
 				91A16813665172FFFA81A455 /* NINChatError.swift in Sources */,
 				91A162DDA99D9DDB9D0B8436 /* Thread+Extension.swift in Sources */,
 				B704E3E68829ED0963294E84 /* NSUserDefaults+Extension.swift in Sources */,
+				B704E8410F0ECA2A17505879 /* URL+Extension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/QuestionnaireDataSourceDelegate.swift
+++ b/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/QuestionnaireDataSourceDelegate.swift
@@ -103,7 +103,7 @@ extension QuestionnaireDataSourceDelegate {
 // MARK: - Cell Setup
 extension QuestionnaireDataSourceDelegate {
     internal func setupDefaultAnswers(element: QuestionnaireElement, option: ElementOption) {
-        self.viewModel.submitAnswer(key: element, value: option.value)
+        _ = self.viewModel.submitAnswer(key: element, value: option.value)
     }
 
     internal func setupSettable(element: QuestionnaireElement & QuestionnaireSettable) {

--- a/NinchatSDKSwift/Implementations/Extensions/NINLowLevelClientProps+Extension.swift
+++ b/NinchatSDKSwift/Implementations/Extensions/NINLowLevelClientProps+Extension.swift
@@ -452,6 +452,7 @@ extension NINLowLevelClientProps: NINLowLevelICEInfoProps {
 
 protocol NINLowLevelFileInfoProps {
     var fileURL: NINResult<String> { get }
+    var thumbnailURL: NINResult<String> { get }
     var urlExpiry: NINResult<Date> { get }
     var thumbnail: NINResult<NINLowLevelClientProps> { get }
     var thumbnailSize: NINResult<CGSize> { get }
@@ -463,6 +464,10 @@ protocol NINLowLevelFileInfoProps {
 extension NINLowLevelClientProps: NINLowLevelFileInfoProps {
     var fileURL: NINResult<String> {
         get { self.get(forKey: "file_url") }
+    }
+
+    var thumbnailURL: NINResult<String> {
+        get { self.get(forKey: "thumbnail_url") }
     }
 
     var urlExpiry: NINResult<Date> {

--- a/NinchatSDKSwift/Implementations/Extensions/String+Extension.swift
+++ b/NinchatSDKSwift/Implementations/Extensions/String+Extension.swift
@@ -104,3 +104,9 @@ extension String {
         return (try? JSONSerialization.jsonObject(with: data, options: .allowFragments)).flatMap { $0 as? T }
     }
 }
+
+extension String {
+    func fetchImage(completion: ((Data) -> Void)? = nil) {
+        URL(string: self)?.fetchImage(completion: completion)
+    }
+}

--- a/NinchatSDKSwift/Implementations/Extensions/UIImageView+Extension.swift
+++ b/NinchatSDKSwift/Implementations/Extensions/UIImageView+Extension.swift
@@ -8,39 +8,20 @@ import UIKit
 
 extension UIImageView {
     func image(from url: String?, completion: ((Data) -> Void)? = nil) {
-        guard let urlStr = url  else { return }
-        self.image(from: URL(string: urlStr), completion: completion)
+        self.image(from: URL(string: url ?? ""), completion: completion)
     }
     
     func image(from url: URL?, completion: ((Data) -> Void)? = nil) {
-        guard let url = url else { return }
-    
-        URLSession.shared.dataTask(with: URLRequest(url: url, cachePolicy: .returnCacheDataElseLoad)) { (data: Data?, response: URLResponse?, error: Error?) in
-            guard
-                let httpURLResponse = response as? HTTPURLResponse, httpURLResponse.statusCode == 200,
-                let mimeType = response?.mimeType, mimeType.hasPrefix("image"),
-                let data = data, error == nil,
-                let image = UIImage(data: data)
-            else { return }
-        
+        url?.fetchImage { [weak self] data in
             DispatchQueue.main.async() {
-                self.image = image
+                self?.image = UIImage(data: data)
                 completion?(data)
             }
-        }.resume()
+        }
     }
 
     func fetchImage(from url: URL?, completion: ((Data) -> Void)? = nil) {
-        guard let url = url else { return }
-        URLSession.shared.dataTask(with: URLRequest(url: url, cachePolicy: .returnCacheDataElseLoad)) { (data: Data?, response: URLResponse?, error: Error?) in
-            guard
-                let httpURLResponse = response as? HTTPURLResponse, httpURLResponse.statusCode == 200,
-                let mimeType = response?.mimeType, mimeType.hasPrefix("image"),
-                let data = data, error == nil
-            else { return }
-
-            DispatchQueue.main.async() { completion?(data) }
-        }.resume()
+        url?.fetchImage(completion: completion)
     }
 
     var tint: UIColor? {

--- a/NinchatSDKSwift/Implementations/Extensions/URL+Extension.swift
+++ b/NinchatSDKSwift/Implementations/Extensions/URL+Extension.swift
@@ -1,0 +1,20 @@
+//
+// Copyright (c) 27.1.2021 Somia Reality Oy. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+import Foundation
+
+extension URL {
+    func fetchImage(completion: ((Data) -> Void)? = nil) {
+        URLSession.shared.dataTask(with: URLRequest(url: self, cachePolicy: .returnCacheDataElseLoad)) { (data: Data?, response: URLResponse?, error: Error?) in
+            guard
+                let httpURLResponse = response as? HTTPURLResponse, httpURLResponse.statusCode == 200,
+                let mimeType = response?.mimeType, mimeType.hasPrefix("image"),
+                let data = data, error == nil
+            else { return }
+            completion?(data)
+        }.resume()
+    }
+}

--- a/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSeesionManagerPrivate.swift
+++ b/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSeesionManagerPrivate.swift
@@ -94,6 +94,10 @@ extension NINChatSessionManagerImpl {
             fileInfoDictionary["urlExpiry"] = expire
         }
 
+        if case let .success(url) = param.thumbnailURL {
+            fileInfoDictionary["thumbnailUrl"] = url
+        }
+
         if case let .success(size) = param.thumbnailSize {
             fileInfoDictionary["aspectRatio"] = Double(size.width/size.height)
         }

--- a/NinchatSDKSwift/Implementations/Models/FileInfo.swift
+++ b/NinchatSDKSwift/Implementations/Models/FileInfo.swift
@@ -12,17 +12,19 @@ final class FileInfo: Codable {
     var mimeType: String!
     var size: Int!
     var url: String?
+    var thumbnailUrl: String?
     var urlExpiry: Date?
     var aspectRatio: Double?
     
     // MARK: - Initializer
     
-    init(fileID: String, name: String, mimeType: String, size: Int, url: String? = nil, urlExpiry: Date? = nil) {
+    init(fileID: String, name: String, mimeType: String, size: Int, url: String? = nil, thumbnailUrl: String? = nil, urlExpiry: Date? = nil) {
         self.fileID = fileID
         self.name = name
         self.mimeType = mimeType
         self.size = size
         self.url = url
+        self.thumbnailUrl = thumbnailUrl
         self.urlExpiry = urlExpiry
     }
     
@@ -66,30 +68,15 @@ final class FileInfo: Codable {
                 if let error = error {
                     completion(error, false)
                 } else if let info = fileInfo {
-                    let file = FileInfo(json: info)
-
-                    self?.url = file.url
-                    self?.urlExpiry = file.urlExpiry
-                    self?.aspectRatio = file.aspectRatio
+                    self?.url = info["url"] as? String
+                    self?.urlExpiry = info["urlExpiry"] as? Date
+                    self?.thumbnailUrl = info["thumbnailUrl"] as? String
+                    self?.aspectRatio = info["aspectRatio"] as? Double
                     completion(nil, true)
                 }
             }
         } catch {
             completion(error, false)
-        }
-    }
-    
-    // MARK: - Codable object
-    
-    struct FileInfo: Codable {
-        let url: String?
-        let urlExpiry: Date?
-        let aspectRatio: Double?
-        
-        init(json: [String:Any]) {
-            self.url = json["url"] as? String
-            self.urlExpiry = json["urlExpiry"] as? Date
-            self.aspectRatio = json["aspectRatio"] as? Double
         }
     }
 }


### PR DESCRIPTION
In accordance with the discussions on somia/mobile#294, the PR makes big impacts on the memory usage of the iOS SDK when a heavy attachment is loaded.

The following screenshots show how the memory usage has changed with the new changes.

![Before PR](https://user-images.githubusercontent.com/11143939/106007621-2c1c3c00-60bf-11eb-9f32-cd24107ee364.png)

<img width="2519" alt="After PR" src="https://user-images.githubusercontent.com/11143939/106007658-33434a00-60bf-11eb-9d16-88c4edbe5b04.png">

