### PR TITLE
feature/describe questionnaire queues

### DIFF
--- a/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSessionManager.swift
+++ b/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSessionManager.swift
@@ -78,6 +78,9 @@ protocol NINChatSessionMessenger: class {
     /* A reference to currently described queue, used for setting queue permissions within the chat view. */
     var describedQueue: Queue? { get }
 
+    /* The realmID that is set when the instance is initiated. **/
+    var realmID: String? { get }
+
     /*
     * The list that keeps a temporary record of `ComposeMessageView` states
     * To satisfy the issue `https://github.com/somia/mobile/issues/218`
@@ -110,6 +113,9 @@ protocol NINChatSessionMessenger: class {
 protocol NINChatSessionAttachment: class {
     /** Describe a file by its ID. */
     func describe(file id: String, completion: @escaping (Error?, [String:Any]?) -> Void) throws
+
+    /* Describe queues for a realm by their IDs. **/
+    func describe(realm id: String, queuesID: [String]?, completion: @escaping CompletionWithError) throws
 }
 
 protocol NINChatSessionTranslation: class {

--- a/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSessionManagerImpl.swift
+++ b/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSessionManagerImpl.swift
@@ -26,7 +26,7 @@ final class NINChatSessionManagerImpl: NSObject, NINChatSessionManager, NINChatD
     internal var currentChannelID: String?
     internal var backgroundChannelID: String?
     internal var myUserID: String?
-    internal var realmID: String?
+    internal(set) var realmID: String?
     internal var channelClosed: Bool = false
     internal var expectedHistoryLength = -1
 

--- a/NinchatSDKSwift/Implementations/View Model/NINQuestionnaireViewModel.swift
+++ b/NinchatSDKSwift/Implementations/View Model/NINQuestionnaireViewModel.swift
@@ -107,11 +107,16 @@ final class NINQuestionnaireViewModelImpl: NINQuestionnaireViewModel {
                 self?.setupPostConnector()
             }
         }
+        let describeQueues = BlockOperation { [weak self] in
+            if questionnaireType == .pre, let realm = self?.sessionManager?.realmID {
+                self?.describeAllQueues(realm: realm)
+            }
+        }
 
         elementsOperation.addDependency(configurationOperation)
         connectorOperation.addDependency(configurationOperation)
         setupConnectorOperation.addDependency(connectorOperation)
-        self.operationQueue.addOperations([configurationOperation, elementsOperation, connectorOperation, setupConnectorOperation], waitUntilFinished: false)
+        self.operationQueue.addOperations([configurationOperation, elementsOperation, connectorOperation, setupConnectorOperation, describeQueues], waitUntilFinished: false)
     }
 
     private func setupPreConnector(queue: Queue) {
@@ -149,6 +154,14 @@ final class NINQuestionnaireViewModelImpl: NINQuestionnaireViewModel {
                 self?.onErrorOccurred?(error)
             }
         }
+    }
+
+    internal func describeAllQueues(realm: String) {
+        let uniqueQueues = configurations.compactMap({ $0.logic?.queueId }).filter({ [weak self] queueID in
+            !(self?.sessionManager?.queues.contains(where: { $0.queueID == queueID }) ?? true)
+        })
+
+        try? sessionManager?.describe(realm: realm, queuesID: uniqueQueues) { _ in }
     }
 
     internal func hasToWaitForUserConfirmation(_ autoApply: Bool) -> Bool {

--- a/NinchatSDKSwiftServerTests/NinchatSDKSwiftServerQuestionnaireTests.swift
+++ b/NinchatSDKSwiftServerTests/NinchatSDKSwiftServerQuestionnaireTests.swift
@@ -36,6 +36,34 @@ final class NinchatSDKSwiftServerQuestionnaireTests: XCTestCase {
         }
         waitForExpectations(timeout: 15.0)
     }
+
+    func test_1_describeQueues() {
+        var viewModel: NINQuestionnaireViewModel!
+        let expect = self.expectation(description: "Expected to describe all queues mentioned in the configurations")
+
+        sessionManager.updateSecureMetadata()
+        sessionManager.fetchSiteConfiguration(config: Session.configurationKey, environments: nil) { error in
+            XCTAssertNil(error)
+
+            try! self.sessionManager.openSession { _, _, error in
+                XCTAssertNil(error)
+
+                try! self.sessionManager.list(queues: self.sessionManager.siteConfiguration.audienceQueues) { error in
+                    XCTAssertNil(error)
+                    XCTAssertFalse(self.sessionManager.queues.contains(where: { $0.queueID == "7s1gafig00ofg" }))
+                    XCTAssertFalse(self.sessionManager.queues.contains(where: { $0.queueID == "76nr0l4m00t5" }))
+
+                    viewModel = NINQuestionnaireViewModelImpl(sessionManager: self.sessionManager, audienceMetadata: self.sessionManager.audienceMetadata, questionnaireType: .pre)
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) {
+                        XCTAssertTrue(self.sessionManager.queues.contains(where: { $0.queueID == "7s1gafig00ofg" }))
+                        XCTAssertTrue(self.sessionManager.queues.contains(where: { $0.queueID == "76nr0l4m00t5" }))
+                        expect.fulfill()
+                    }
+                }
+            }
+        }
+        waitForExpectations(timeout: 15.0)
+    }
 }
 
 private extension NINChatSessionManagerImpl {

--- a/NinchatSDKSwiftTests/NINQuestionnaireViewModelTests.swift
+++ b/NinchatSDKSwiftTests/NINQuestionnaireViewModelTests.swift
@@ -70,7 +70,7 @@ final class NINQuestionnaireViewModelTests: XCTestCase {
         }
     }
 
-    func test_21_setPreAnswers() throws {
+    func test_21_setPreAnswers() {
         self.viewModel?.pageNumber = 0
 
         do {

--- a/NinchatSDKSwiftTests/Resources/questionnaire-mock.json
+++ b/NinchatSDKSwiftTests/Resources/questionnaire-mock.json
@@ -188,6 +188,7 @@
             "Epäilys-jatko": "Sulje"
           }
         ],
+        "queueId": "7s1gafig00ofg",
         "target": "_register"
       }
     },
@@ -654,6 +655,7 @@
             "temp-btn2": "Finnish"
           }
         ],
+        "queueId": "76nr0l4m00t5",
         "target": "_complete",
         "tags": [
           "7fvo5p8700eao",


### PR DESCRIPTION
With the new PR, all distinct queue ids that are in `preAudienceQuestionnaire` as logic targets get described in the background once the session is initiated. 
With this approach, the SDK avoids describing all queues that may have performance costs for both the client and the server.
