### PR TITLE
fix/single queue target

### DIFF
--- a/NinchatSDKSwift/Implementations/Utilities/QuestionnaireElementConnector.swift
+++ b/NinchatSDKSwift/Implementations/Utilities/QuestionnaireElementConnector.swift
@@ -8,6 +8,7 @@ import UIKit
 
 protocol QuestionnaireElementConnector {
     var logicContainsTags: ((LogicQuestionnaire?) -> Void)? { get set }
+    var logicContainsQueueID: ((LogicQuestionnaire?) -> Void)? { get set }
     var onRegisterTargetReached: ((LogicQuestionnaire?, ElementRedirect?, _ autoApply: Bool) -> Void)? { get set }
     var onCompleteTargetReached: ((LogicQuestionnaire?, ElementRedirect?, _ autoApply: Bool) -> Void)? { get set }
 
@@ -27,6 +28,7 @@ struct QuestionnaireElementConnectorImpl: QuestionnaireElementConnector {
     }
 
     var logicContainsTags: ((LogicQuestionnaire?) -> Void)?
+    var logicContainsQueueID: ((LogicQuestionnaire?) -> Void)?
     var onRegisterTargetReached: ((LogicQuestionnaire?, ElementRedirect?, _ autoApply: Bool) -> Void)?
     var onCompleteTargetReached: ((LogicQuestionnaire?, ElementRedirect?, _ autoApply: Bool) -> Void)?
 
@@ -113,6 +115,9 @@ extension QuestionnaireElementConnectorImpl {
         if block.satisfy(dictionary: answers) {
             if let tags = block.tags, tags.count > 0 {
                 self.logicContainsTags?(block)
+            }
+            if let queueId = block.queueId, !queueId.isEmpty {
+                self.logicContainsQueueID?(block)
             }
 
             if block.target == "_register", performClosures {

--- a/NinchatSDKSwiftTests/NINQuestionnaireViewModelTests.swift
+++ b/NinchatSDKSwiftTests/NINQuestionnaireViewModelTests.swift
@@ -306,4 +306,44 @@ final class NINQuestionnaireViewModelTests: XCTestCase {
         XCTAssertEqual(self.viewModel?.answers, ["Aiheet": "Mikä on koronavirus"])
         XCTAssertEqual(self.viewModel?.pageNumber, 1)
     }
+
+    func test_80_logicWithTagsAndCompelte() {
+        let element = self.connector.configurations.first(where: { $0.name == "start-Logic" })?.logic
+        let expect_tags = self.expectation(description: "Expected to submit tags of the logic")
+        let expect_complete = self.expectation(description: "Expected to reach _complete logic")
+
+        self.viewModel?.connector.logicContainsTags = { logic in
+            XCTAssertNotNil(logic?.tags)
+            XCTAssertEqual(logic?.tags?.count ?? 0, 2)
+            expect_tags.fulfill()
+        }
+        self.viewModel?.connector.onCompleteTargetReached = { _, _, autoApply in
+            XCTAssertTrue(self.viewModel!.hasToWaitForUserConfirmation(autoApply))
+            expect_complete.fulfill()
+        }
+        self.viewModel?.answers = ["temp-btn": "Finnish", "temp-btn2": "Finnish"]
+        _ = self.viewModel?.logicTargetPage(element!, autoApply: true)
+
+        waitForExpectations(timeout: 2.0)
+    }
+
+    func test_90_logicWithQueuesAndComplete() {
+        let element = self.connector.configurations.first(where: { $0.name == "start-Logic" })?.logic
+        let expect_queueId = self.expectation(description: "Expected to submit queue id of the logic")
+        let expect_complete = self.expectation(description: "Expected to reach _complete logic")
+
+        self.viewModel?.connector.logicContainsTags = { logic in
+            XCTAssertNotNil(logic?.queueId)
+            XCTAssertEqual(logic?.queueId, "76nr0l4m00t5")
+            expect_queueId.fulfill()
+        }
+        self.viewModel?.connector.onCompleteTargetReached = { _, _, autoApply in
+            XCTAssertTrue(self.viewModel!.hasToWaitForUserConfirmation(autoApply))
+            expect_complete.fulfill()
+        }
+        self.viewModel?.answers = ["temp-btn": "Finnish", "temp-btn2": "Finnish"]
+        _ = self.viewModel?.logicTargetPage(element!, autoApply: true)
+
+        waitForExpectations(timeout: 2.0)
+    }
 }


### PR DESCRIPTION
The PR saves the queue id from the reached logic block even if the logic has a target other than `_complete`. The saved queue later can be used for registration or completion.
