### PR TITLE
fix/improve overriding

### DIFF
--- a/NinchatSDKSwift/Implementations/Constants.swift
+++ b/NinchatSDKSwift/Implementations/Constants.swift
@@ -56,6 +56,8 @@ public enum ColorConstants {
     case chatTimestamp
     case chatBubbleLeftText
     case chatBubbleRightText
+    case chatBubbleLeftTint
+    case chatBubbleRightTint
     case textareaText
     case textareaSubmit
     case textareaSubmitText

--- a/NinchatSDKSwift/Implementations/Constants.swift
+++ b/NinchatSDKSwift/Implementations/Constants.swift
@@ -63,6 +63,7 @@ public enum ColorConstants {
     case textareaText
     case textareaSubmit
     case textareaSubmitText
+    case textareaSubmitBorder
     case textareaPlaceholder
     case chatBubbleLeftLink
     case chatBubbleRightLink

--- a/NinchatSDKSwift/Implementations/Constants.swift
+++ b/NinchatSDKSwift/Implementations/Constants.swift
@@ -58,6 +58,8 @@ public enum ColorConstants {
     case chatBubbleRightText
     case chatBubbleLeftTint
     case chatBubbleRightTint
+    case chatCloseButtonBackground
+    case chatCloseButtonBorder
     case textareaText
     case textareaSubmit
     case textareaSubmitText

--- a/NinchatSDKSwift/Implementations/Constants.swift
+++ b/NinchatSDKSwift/Implementations/Constants.swift
@@ -63,6 +63,7 @@ public enum ColorConstants {
     case textareaText
     case textareaSubmit
     case textareaSubmitText
+    case textareaPlaceholder
     case chatBubbleLeftLink
     case chatBubbleRightLink
     case modalText

--- a/NinchatSDKSwift/Implementations/Managers/NINChatSession Internal/NINChatSessionInternal.swift
+++ b/NinchatSDKSwift/Implementations/Managers/NINChatSession Internal/NINChatSessionInternal.swift
@@ -97,7 +97,7 @@ extension NINChatSessionInternalDelegate {
     }
 
     var colorAssetsDictionary: [ColorConstants:UIColor] {
-        let colorKeys: [ColorConstants] = [.infoText, .chatName, .chatTimestamp, .chatBubbleLeftText, .chatBubbleRightText, .chatBubbleLeftLink, .chatBubbleRightLink]
+        let colorKeys: [ColorConstants] = [.infoText, .chatName, .chatTimestamp, .chatBubbleLeftText, .chatBubbleLeftTint, .chatBubbleRightText, .chatBubbleRightTint, .chatBubbleLeftLink, .chatBubbleRightLink]
         return colorKeys.compactMap({ ($0, self.override(colorAsset: $0)) }).reduce(into: [:]) { (colorAsset: inout [ColorConstants:UIColor], tuple: (key: ColorConstants, color: UIColor?)) in
             colorAsset[tuple.key] = tuple.color
         }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Button/CloseButton.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Button/CloseButton.swift
@@ -67,7 +67,15 @@ final class CloseButton: UIView, CloseButtonProtocol {
             self.layer.borderWidth = 0
         }
 
-        if buttonTitle.isEmpty, let overrideImage = session?.override(imageAsset: .chatCloseButtonEmpty) {
+        if let backgroundColor = session?.override(colorAsset: .chatCloseButtonBackground) {
+            self.backgroundColor = backgroundColor
+
+            if let borderColor = session?.override(colorAsset: .chatCloseButtonBorder) {
+                self.layer.borderColor = borderColor.cgColor
+            }
+        }
+        /// Set images only if the button has no bakground color
+        else if buttonTitle.isEmpty, let overrideImage = session?.override(imageAsset: .chatCloseButtonEmpty) {
             shapeButton(image: overrideImage)
         } else if let overrideImage = session?.override(imageAsset: .chatCloseButton) {
             shapeButton(image: overrideImage)
@@ -82,7 +90,6 @@ final class CloseButton: UIView, CloseButtonProtocol {
         if let textColor = session?.override(colorAsset: .buttonSecondaryText) {
             self.theButton.setTitleColor(textColor, for: .normal)
             self.closeButtonImageView.tintColor = textColor
-            self.layer.borderColor = textColor.cgColor
         }
 
         self.updateConstraints()

--- a/NinchatSDKSwift/Implementations/View/UIKit/Button/CloseButton.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Button/CloseButton.swift
@@ -61,21 +61,17 @@ final class CloseButton: UIView, CloseButtonProtocol {
             self.theButton.backgroundColor = .clear
             self.theButton.layer.cornerRadius = 0
             self.theButton.layer.borderWidth = 0
-
-            self.backgroundColor = .clear
-            self.layer.cornerRadius = 0
-            self.layer.borderWidth = 0
         }
 
         if let backgroundColor = session?.override(colorAsset: .chatCloseButtonBackground) {
             self.backgroundColor = backgroundColor
-
-            if let borderColor = session?.override(colorAsset: .chatCloseButtonBorder) {
-                self.layer.borderColor = borderColor.cgColor
-            }
         }
-        /// Set images only if the button has no bakground color
-        else if buttonTitle.isEmpty, let overrideImage = session?.override(imageAsset: .chatCloseButtonEmpty) {
+
+        if let borderColor = session?.override(colorAsset: .chatCloseButtonBorder) {
+            self.layer.borderColor = borderColor.cgColor
+        }
+
+        if buttonTitle.isEmpty, let overrideImage = session?.override(imageAsset: .chatCloseButtonEmpty) {
             shapeButton(image: overrideImage)
         } else if let overrideImage = session?.override(imageAsset: .chatCloseButton) {
             shapeButton(image: overrideImage)

--- a/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Channel Cell/ChatChannelCell.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Channel Cell/ChatChannelCell.swift
@@ -129,7 +129,7 @@ class ChatChannelMineCell: ChatChannelCell {
         self.bubbleImageView.image = (series) ? imageAssets?[.chatBubbleRightRepeated] : imageAssets?[.chatBubbleRight]
         
         /// White text on black bubble
-        self.bubbleImageView.tintColor = .black
+        self.bubbleImageView.tintColor = colorAssets?[.chatBubbleRightTint] ?? .black
         if let name = config?.nameOverride, !name.isEmpty {
             self.senderNameLabel.text = name
         }
@@ -175,7 +175,7 @@ class ChatChannelOthersCell: ChatChannelCell {
         self.bubbleImageView.image = (series) ? imageAssets?[.chatBubbleLeftRepeated] : imageAssets?[.chatBubbleLeft]
         
         /// Black text on white bubble
-        self.bubbleImageView.tintColor = .white
+        self.bubbleImageView.tintColor = colorAssets?[.chatBubbleLeftTint] ?? .white
         if let name = config?.nameOverride, !name.isEmpty {
             self.senderNameLabel.text = name
         }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Input Controls/ChatInputControls.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Input Controls/ChatInputControls.swift
@@ -111,6 +111,10 @@ final class ChatInputControls: UIView, ChatInputControlsProtocol {
             self.textInput.textColor = inputTextColor
             textColor = inputTextColor
         }
+
+        if let placeholderColor = self.delegate?.override(colorAsset: .textareaPlaceholder) {
+            self.placeholderColor = placeholderColor
+        }
         self.updatePlaceholder()
     }
 

--- a/NinchatSDKSwift/Implementations/View/UIKit/Input Controls/ChatInputControls.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Input Controls/ChatInputControls.swift
@@ -87,7 +87,11 @@ final class ChatInputControls: UIView, ChatInputControlsProtocol {
             if let backgroundColor = self.delegate?.override(colorAsset: .textareaSubmit) {
                 self.sendMessageButton.backgroundColor = backgroundColor
                 self.sendMessageButton.layer.masksToBounds = true
-                self.sendMessageButton.layer.cornerRadius = 16.0
+            }
+
+            if let borderColor = self.delegate?.override(colorAsset: .textareaSubmitBorder) {
+                self.sendMessageButton.layer.borderWidth = 1.0
+                self.sendMessageButton.layer.borderColor = borderColor.cgColor
             }
             
             if let backgroundImage = self.delegate?.override(imageAsset: .textareaSubmitButton) {

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementCheckbox.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementCheckbox.swift
@@ -35,7 +35,7 @@ final class QuestionnaireElementCheckbox: UIView, QuestionnaireElement, Question
         }
     }
     var elementConfiguration: QuestionnaireConfiguration?
-    internal(set) var elementHeight: CGFloat {
+    var elementHeight: CGFloat {
         get {
             let viewHeight = CGFloat(self.view.height!.constant) + 16.0
             if self.subElements.count == 0, index == 0 {

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementRadio.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementRadio.swift
@@ -34,7 +34,7 @@ class QuestionnaireElementRadio: UIView, QuestionnaireElementWithTitle, Question
         }
     }
     var elementConfiguration: QuestionnaireConfiguration?
-    internal(set) var elementHeight: CGFloat = 0
+    var elementHeight: CGFloat = 0
 
     func overrideAssets(with delegate: NINChatSessionInternalDelegate?) {
         self.overrideTitle(delegate: delegate)

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementSelect.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementSelect.swift
@@ -34,7 +34,7 @@ final class QuestionnaireElementSelect: UIView, QuestionnaireElementWithTitle, Q
         }
     }
     var elementConfiguration: QuestionnaireConfiguration?
-    internal(set) var elementHeight: CGFloat = 0
+    var elementHeight: CGFloat = 0
 
     func overrideAssets(with delegate: NINChatSessionInternalDelegate?) {
         self.overrideTitle(delegate: delegate)

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementText.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementText.swift
@@ -42,6 +42,9 @@ final class QuestionnaireElementText: UITextView, QuestionnaireElement {
         if let overriddenColor = delegate?.override(questionnaireAsset: .titleTextColor) {
             self.setAttributed(text: self.elementConfiguration?.label ?? "", font: .ninchat, color: overriddenColor, width:  self.estimatedWidth())
         }
+        if let linkColor = delegate?.override(colorAsset: .link) {
+            self.linkTextAttributes = [NSAttributedString.Key.foregroundColor: linkColor]
+        }
     }
 
     // MARK: - UIView life-cycle

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextArea.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextArea.swift
@@ -31,7 +31,7 @@ final class QuestionnaireElementTextArea: UIView, QuestionnaireElementWithTitle,
         }
     }
     var elementConfiguration: QuestionnaireConfiguration?
-    internal(set) var elementHeight: CGFloat = 0
+    var elementHeight: CGFloat = 0
 
     func overrideAssets(with delegate: NINChatSessionInternalDelegate?) {
         self.overrideTitle(delegate: delegate)

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextField.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextField.swift
@@ -31,7 +31,7 @@ final class QuestionnaireElementTextField: UIView, QuestionnaireElementWithTitle
         }
     }
     var elementConfiguration: QuestionnaireConfiguration?
-    internal(set) var elementHeight: CGFloat = 0
+    var elementHeight: CGFloat = 0
 
     func overrideAssets(with delegate: NINChatSessionInternalDelegate?) {
         self.overrideTitle(delegate: delegate)


### PR DESCRIPTION
- Questionnaire: Text: add link color override
- compiler: remove warnings
- asset: color: add background color for chat bubbles
- asset: color: add keys for close buttons
- asset: color: set color for placeholder in the input area
- asset: color: set border color for send button
- asset: color: fix 510cf2a

Adding options to override `borderRadius` seems to need a new delegate function.
