### PR TITLE
asset: layer: add delegate for overriding CALayer

### DIFF
--- a/NinchatSDKSwift/Implementations/Constants.swift
+++ b/NinchatSDKSwift/Implementations/Constants.swift
@@ -59,11 +59,9 @@ public enum ColorConstants {
     case chatBubbleLeftTint
     case chatBubbleRightTint
     case chatCloseButtonBackground
-    case chatCloseButtonBorder
     case textareaText
     case textareaSubmit
     case textareaSubmitText
-    case textareaSubmitBorder
     case textareaPlaceholder
     case chatBubbleLeftLink
     case chatBubbleRightLink
@@ -77,6 +75,14 @@ public enum ColorConstants {
     case ratingPositiveText
     case ratingNeutralText
     case ratingNegativeText
+}
+
+/// Color override keys
+public typealias NINLayerAssetDictionary = [CALayerConstant:CALayer]
+public let LAYER_NAME = "_ninchat-asset"
+public enum CALayerConstant {
+    case chatCloseButtonLayer
+    case textareaSubmitLayer
 }
 
 /// Questionnaire override keys

--- a/NinchatSDKSwift/Implementations/Extensions/UIView+Extension.swift
+++ b/NinchatSDKSwift/Implementations/Extensions/UIView+Extension.swift
@@ -93,3 +93,11 @@ extension UIView {
         }
     }
 }
+
+extension UIView {
+    static func applyLayerOverride(view: UIView) {
+        view.layer.sublayers?.filter({ $0.name == LAYER_NAME }).forEach({
+            $0.frame = view.bounds
+        })
+    }
+}

--- a/NinchatSDKSwift/Implementations/Managers/NINChatSession Internal/NINChatSessionInternal.swift
+++ b/NinchatSDKSwift/Implementations/Managers/NINChatSession Internal/NINChatSessionInternal.swift
@@ -17,6 +17,7 @@ protocol NINChatSessionInternalDelegate {
     func onResumeFailed() -> Bool
     func override(imageAsset key: AssetConstants) -> UIImage?
     func override(colorAsset key: ColorConstants) -> UIColor?
+    func override(layerAsset key: CALayerConstant) -> CALayer?
     func override(questionnaireAsset key: QuestionnaireColorConstants) -> UIColor?
 }
 
@@ -73,6 +74,14 @@ struct InternalDelegate: NINChatSessionInternalDelegate {
         return session.delegate?.ninchat(session, overrideColorAssetForKey: key)
     }
 
+    internal func override(layerAsset key: CALayerConstant) -> CALayer? {
+        guard let session = self.session else { return nil }
+        let layer = session.delegate?.ninchat(session, overrideLayer: key)
+        layer?.name = LAYER_NAME
+        
+        return layer
+    }
+    
     internal func override(questionnaireAsset key: QuestionnaireColorConstants) -> UIColor? {
         guard let session = self.session else { return nil }
         return session.delegate?.ninchat(session, overrideQuestionnaireColorAssetKey: key)

--- a/NinchatSDKSwift/Implementations/View/UIKit/Button/CloseButton.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Button/CloseButton.swift
@@ -49,6 +49,11 @@ final class CloseButton: UIView, CloseButtonProtocol {
         }
     }
     
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        UIView.applyLayerOverride(view: self)
+    }
+    
     func overrideAssets(with session: NINChatSessionInternalDelegate?) {
         self.theButton.titleLabel?.font = .ninchat
         self.round(borderWidth: 1.0, borderColor: .defaultBackgroundButton)
@@ -67,8 +72,8 @@ final class CloseButton: UIView, CloseButtonProtocol {
             self.backgroundColor = backgroundColor
         }
 
-        if let borderColor = session?.override(colorAsset: .chatCloseButtonBorder) {
-            self.layer.borderColor = borderColor.cgColor
+        if let layer = session?.override(layerAsset: .chatCloseButtonLayer) {
+            self.layer.addSublayer(layer)
         }
 
         if buttonTitle.isEmpty, let overrideImage = session?.override(imageAsset: .chatCloseButtonEmpty) {

--- a/NinchatSDKSwift/Implementations/View/UIKit/Input Controls/ChatInputControls.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Input Controls/ChatInputControls.swift
@@ -76,6 +76,11 @@ final class ChatInputControls: UIView, ChatInputControlsProtocol {
     @IBOutlet private(set) weak var sendMessageButton: UIButton!
     @IBOutlet private(set) weak var sendMessageButtonWidthConstraint: NSLayoutConstraint!
     
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        UIView.applyLayerOverride(view: self.sendMessageButton)
+    }
+    
     func overrideAssets() {
         if let sendButtonTitle = self.sessionManager?.siteConfiguration.sendButtonTitle {
             self.sendMessageButtonWidthConstraint.isActive = false
@@ -86,14 +91,8 @@ final class ChatInputControls: UIView, ChatInputControlsProtocol {
             
             if let backgroundColor = self.delegate?.override(colorAsset: .textareaSubmit) {
                 self.sendMessageButton.backgroundColor = backgroundColor
-                self.sendMessageButton.layer.masksToBounds = true
             }
 
-            if let borderColor = self.delegate?.override(colorAsset: .textareaSubmitBorder) {
-                self.sendMessageButton.layer.borderWidth = 1.0
-                self.sendMessageButton.layer.borderColor = borderColor.cgColor
-            }
-            
             if let backgroundImage = self.delegate?.override(imageAsset: .textareaSubmitButton) {
                 self.sendMessageButton.setBackgroundImage(backgroundImage, for: .normal)
             } else if let backgroundBundle = UIImage(named: "icon_send_message_border", in: .SDKBundle, compatibleWith: nil) {
@@ -103,6 +102,11 @@ final class ChatInputControls: UIView, ChatInputControlsProtocol {
             if let titleColor = self.delegate?.override(colorAsset: .textareaSubmitText) {
                 self.sendMessageButton.setTitleColor(titleColor, for: .normal)
             }
+            
+            if let layer = self.delegate?.override(layerAsset: .textareaSubmitLayer) {
+                self.sendMessageButton.layer.addSublayer(layer)
+            }
+            
         } else if let buttonImage = self.delegate?.override(imageAsset: .textareaSubmitButton) {
             self.sendMessageButton.setImage(buttonImage, for: .normal)
         }

--- a/NinchatSDKSwift/NINChatSessionDelegate.swift
+++ b/NinchatSDKSwift/NINChatSessionDelegate.swift
@@ -49,6 +49,17 @@ public protocol NINChatSessionDelegate: class {
     func ninchat(_ session: NINChatSession, overrideColorAssetForKey assetKey: ColorConstants) -> UIColor?
 
     /**
+    * This method allows the SDK user to override CALayer for UIKit components used in the SDK UI.
+    * If the implementation does not wish to override a specific asset, nil should
+    * be returned for that key.
+    *
+    * For available asset key constants, see documentation.
+    *
+    * Optional method.
+    */
+    func ninchat(_ session: NINChatSession, overrideLayer assetKey: CALayerConstant) -> CALayer?
+    
+    /**
     * This method allows the SDK user to override color assets for questionnaires used in the SDK UI.
     * If the implementation does not wish to override a specific asset, nil should
     * be returned for that key.


### PR DESCRIPTION
Having the option to override (or in fact, add) a CALayer to UIView items
would be super powerful for users. They can control how the view is shown,
including border, corner, background, etc.

The commit removes newly declread color keys for borders. The same shall
be applied later to other keys
