### PR TITLE
questionnaire/regex-redirect

### DIFF
--- a/NinchatSDKSwift/Implementations/Utilities/QuestionnaireElementConnector.swift
+++ b/NinchatSDKSwift/Implementations/Utilities/QuestionnaireElementConnector.swift
@@ -88,6 +88,10 @@ extension QuestionnaireElementConnectorImpl {
             return redirect
         } else if let redirect = configuration.redirects?.first(where: { $0.pattern ?? AnyHashable("") == input }) {
             return redirect
+        } else if let redirect = configuration.redirects?.first(where: { $0.pattern == nil }) {
+            /// if the input was not matched with the redirect with a valid pattern,
+            /// use the one that has no patterns if there is any (which is applied to all inputs)
+            return redirect
         }
         return nil
     }


### PR DESCRIPTION
Fixes a bug mentioned in somia/mobile#321 on accessing a redirect block with regex. The issue was due to a missed condition to returning the valid redirect block when it has no patterns.