### PR TITLE
Styling/expand layer delegate 331

### DIFF
--- a/NinchatSDKSwift.podspec
+++ b/NinchatSDKSwift.podspec
@@ -31,7 +31,8 @@ Pod::Spec.new do |s|
   # In addition we must suppress 'illegal text relocation' error for i386 platform
   s.pod_target_xcconfig = {
     "OTHER_LDFLAGS[arch=i386]" => "-Wl,-read_only_relocs,suppress -lstdc++",
-    "ENABLE_BITCODE" => "NO"
+    "ENABLE_BITCODE" => "NO",
+    "SWIFT_SUPPRESS_WARNINGS" => "YES"
   }
   s.user_target_xcconfig = {
       "ENABLE_BITCODE" => "NO"

--- a/NinchatSDKSwift.xcodeproj/project.pbxproj
+++ b/NinchatSDKSwift.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5C06A648261DB1EA00873B33 /* UIResponder+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C06A647261DB1EA00873B33 /* UIResponder+Extension.swift */; };
 		5C5658CD25EF780F004ED98F /* QuestionnaireTypingCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5C5658CC25EF780F004ED98F /* QuestionnaireTypingCell.xib */; };
 		5C5658D225EF7F77004ED98F /* QuestionnaireTypingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C5658D125EF7F77004ED98F /* QuestionnaireTypingCell.swift */; };
 		5CD4F1C82540CAAF009856AC /* Notification+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CD4F1C62540CAAF009856AC /* Notification+Extension.swift */; };
@@ -236,6 +237,7 @@
 		3FEAD27BEEC9ED9A48EB128E /* Pods_NinchatSDKSwiftTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NinchatSDKSwiftTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		495ADA60487CD354EDC07332 /* Pods_NinchatSDKSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NinchatSDKSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		51577DDC11F36A3D9573A68C /* Pods_NinchatSDKSwiftUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NinchatSDKSwiftUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5C06A647261DB1EA00873B33 /* UIResponder+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIResponder+Extension.swift"; sourceTree = "<group>"; };
 		5C5658CC25EF780F004ED98F /* QuestionnaireTypingCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = QuestionnaireTypingCell.xib; sourceTree = "<group>"; };
 		5C5658D125EF7F77004ED98F /* QuestionnaireTypingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionnaireTypingCell.swift; sourceTree = "<group>"; };
 		5CD4F1C62540CAAF009856AC /* Notification+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Notification+Extension.swift"; sourceTree = "<group>"; };
@@ -709,6 +711,7 @@
 				91A16E7CDA2F9D24FF1BE1DC /* Thread+Extension.swift */,
 				B704E5FC177573DF56D2369A /* NSUserDefaults+Extension.swift */,
 				B704E5C0EFFB626F12366601 /* URL+Extension.swift */,
+				5C06A647261DB1EA00873B33 /* UIResponder+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1456,6 +1459,7 @@
 				91A16A7280B85CB8BD7C87F2 /* SiteConfigRequest.swift in Sources */,
 				5CD4F1C92540CAAF009856AC /* KeyboardHandler.swift in Sources */,
 				91A1638816BBEC6D20425AC2 /* Empty.swift in Sources */,
+				5C06A648261DB1EA00873B33 /* UIResponder+Extension.swift in Sources */,
 				91A1636EC2133F4BE4B586E8 /* ChoiceDialogue.swift in Sources */,
 				91A16B2F768C5422B895C769 /* Toast.swift in Sources */,
 				91A161EC840C41258CBA12A4 /* NINSessionCredentials.swift in Sources */,

--- a/NinchatSDKSwift/Implementations/Constants.swift
+++ b/NinchatSDKSwift/Implementations/Constants.swift
@@ -33,6 +33,7 @@ public enum AssetConstants {
     case ninchatIconRatingPositive
     case ninchatIconRatingNeutral
     case ninchatIconRatingNegative
+    case ninchatQuestionnaireBackground
 
     /* DEPRECATED
      * Use new keys above or CALayerConstant instead
@@ -99,16 +100,8 @@ public enum AssetConstants {
     case iconRatingNeutral
     @available(*, deprecated, renamed: "ninchatIconRatingNegative")
     case iconRatingNegative
-
-
-    @available(*, deprecated, message: "use QuestionnaireAssetConstants.questionnaireBackground")
+    @available(*, deprecated, renamed: "ninchatQuestionnaireBackground")
     case questionnaireBackground
-    /*
-     * ninchat_icon_textarea_submit_button
-     * ninchat_ui_compose_select_button
-     * ninchat_ui_compose_select_button_selected
-     * ninchat_ui_compose_select_submit
-     */
 }
 
 /// Color override keys
@@ -194,8 +187,7 @@ public enum ColorConstants {
     case ratingNegativeText
 }
 
-/// Color override keys
-public typealias NINLayerAssetDictionary = [CALayerConstant:CALayer]
+/// Layer override keys
 public let LAYER_NAME = "_ninchat-asset"
 public enum CALayerConstant {
     case ninchatPrimaryButton
@@ -218,8 +210,7 @@ public enum CALayerConstant {
     case ninchatQuestionnaireNavigationBack
 }
 
-/// Questionnaire override keys
-public typealias NINQuestionnaireDictionary = [QuestionnaireColorConstants:String]
+/// Questionnaire color override keys
 public enum QuestionnaireColorConstants {
     case ninchatQuestionnaireColorTitleText
     case ninchatQuestionnaireColorTextInput
@@ -271,11 +262,6 @@ public enum QuestionnaireColorConstants {
     case navigationNextBackground
     @available(*, deprecated, message: "use CALayerConstant.ninchatQuestionnaireNavigationBack")
     case navigationBackBackground
-}
-
-public enum QuestionnaireAssetConstants {
-    /// Background image
-    case questionnaireBackground
 }
 
 // MARK: - Constants used within the SDK

--- a/NinchatSDKSwift/Implementations/Constants.swift
+++ b/NinchatSDKSwift/Implementations/Constants.swift
@@ -54,13 +54,13 @@ public enum AssetConstants {
     case chatCloseButtonEmpty
     @available(*, deprecated, message: "use CALayerConstant.ninchatChatCloseButton")
     case iconChatCloseButton
-    @available(*, deprecated, message: "use CALayerConstant.ninchatChatBubbleLeft")
+    @available(*, unavailable, message: "the item cannot be overridden by images. use ColorConstants.ninchatColorChatBubbleLeftText and ColorConstants.ninchatColorChatBubbleLeftTint instead")
     case chatBubbleLeft
-    @available(*, deprecated, message: "use CALayerConstant.ninchatChatBubbleLeftRepeated")
+    @available(*, unavailable, message: "the item cannot be overridden by images. use ColorConstants.ninchatColorChatBubbleLeftText and ColorConstants.ninchatColorChatBubbleLeftTint instead")
     case chatBubbleLeftRepeated
-    @available(*, deprecated, message: "use CALayerConstant.ninchatChatBubbleRight")
+    @available(*, unavailable, message: "the item cannot be overridden by images. use ColorConstants.ninchatColorChatBubbleRightText and ColorConstants.ninchatColorChatBubbleRightTint instead")
     case chatBubbleRight
-    @available(*, deprecated, message: "use CALayerConstant.ninchatChatBubbleRightRepeated")
+    @available(*, unavailable, message: "the item cannot be overridden by images. use ColorConstants.ninchatColorChatBubbleRightText and ColorConstants.ninchatColorChatBubbleRightTint instead")
     case chatBubbleRightRepeated
     @available(*, deprecated, renamed: "ninchatChatAvatarRight")
     case chatAvatarRight
@@ -192,10 +192,6 @@ public let LAYER_NAME = "_ninchat-asset"
 public enum CALayerConstant {
     case ninchatPrimaryButton
     case ninchatSecondaryButton
-    case ninchatChatBubbleLeft
-    case ninchatChatBubbleRight
-    case ninchatChatBubbleLeftRepeated
-    case ninchatChatBubbleRightRepeated
     case ninchatChatCloseButton
     case ninchatChatCloseEmptyButton
     case ninchatTextareaSubmitButton

--- a/NinchatSDKSwift/Implementations/Constants.swift
+++ b/NinchatSDKSwift/Implementations/Constants.swift
@@ -201,10 +201,6 @@ public enum CALayerConstant {
     case ninchatBackgroundBottom
     case ninchatQuestionnaireRadioSelected
     case ninchatQuestionnaireRadioUnselected
-    case ninchatQuestionnaireCheckboxSelectedIndicator
-    case ninchatQuestionnaireCheckboxUnselectedIndicator
-    case ninchatQuestionnaireSelectSelected
-    case ninchatQuestionnaireUnselectSelected
     case ninchatQuestionnaireNavigationNext
     case ninchatQuestionnaireNavigationBack
 }
@@ -216,9 +212,13 @@ public enum QuestionnaireColorConstants {
     case ninchatQuestionnaireColorRadioSelectedText
     case ninchatQuestionnaireColorRadioUnselectedText
     case ninchatQuestionnaireColorCheckboxSelectedText
+    case ninchatQuestionnaireCheckboxSelectedIndicator
     case ninchatQuestionnaireColorCheckboxUnselectedText
+    case ninchatQuestionnaireCheckboxUnselectedIndicator
     case ninchatQuestionnaireColorSelectSelectedText
+    case ninchatQuestionnaireSelectSelected
     case ninchatQuestionnaireColorSelectUnselectText
+    case ninchatQuestionnaireSelectUnselected
     case ninchatQuestionnaireColorNavigationNextText
     case ninchatQuestionnaireColorNavigationBackText
 
@@ -241,17 +241,17 @@ public enum QuestionnaireColorConstants {
     case checkboxPrimaryText
     @available(*, deprecated, renamed: "ninchatQuestionnaireColorCheckboxUnselectedText")
     case checkboxSecondaryText
-    @available(*, deprecated, message: "use CALayerConstant.ninchatQuestionnaireCheckboxSelectedIndicator")
+    @available(*, deprecated, renamed: "ninchatQuestionnaireCheckboxSelectedIndicator")
     case checkboxSelectedIndicator
-    @available(*, deprecated, message: "use CALayerConstant.ninchatQuestionnaireCheckboxUnselectedIndicator")
+    @available(*, deprecated, renamed: "ninchatQuestionnaireCheckboxUnselectedIndicator")
     case checkboxDeselectedIndicator
     @available(*, deprecated, renamed: "ninchatQuestionnaireColorSelectSelectedText")
     case selectSelectedText
     @available(*, deprecated, renamed: "ninchatQuestionnaireColorSelectUnselectText")
     case selectNormalText
-    @available(*, deprecated, message: "use CALayerConstant.ninchatQuestionnaireSelectSelected")
+    @available(*, deprecated, renamed: "ninchatQuestionnaireSelectSelected")
     case selectSelectedBackground
-    @available(*, deprecated, message: "use CALayerConstant.ninchatQuestionnaireUnselectSelected")
+    @available(*, deprecated, renamed: "ninchatQuestionnaireSelectUnselected")
     case selectDeselectedBackground
     @available(*, deprecated, renamed: "ninchatQuestionnaireColorNavigationNextText")
     case navigationNextText

--- a/NinchatSDKSwift/Implementations/Constants.swift
+++ b/NinchatSDKSwift/Implementations/Constants.swift
@@ -18,13 +18,13 @@ public enum AssetConstants {
     case ninchatChatAvatarRight
     case ninchatChatAvatarLeft
     case ninchatChatPlayVideo
-    case ninchatIconTextareaCamera
+    case ninchatIconTextareaCamera      /* not used */
     case ninchatIconTextareaAttachment
     case ninchatIconDownload
-    case ninchatIconVideoToggleFull
-    case ninchatIconVideoToggleNormal
-    case ninchatIconVideoSoundOn
-    case ninchatIconVideoSoundOff
+    case ninchatIconVideoToggleFull     /* not used */
+    case ninchatIconVideoToggleNormal   /* not used */
+    case ninchatIconVideoSoundOn        /* not used */
+    case ninchatIconVideoSoundOff       /* not used */
     case ninchatIconVideoMicrophoneOn
     case ninchatIconVideoMicrophoneOff
     case ninchatIconVideoCameraOn
@@ -50,7 +50,7 @@ public enum AssetConstants {
     case secondaryButton
     @available(*, deprecated, message: "use CALayerConstant.ninchatChatCloseButton")
     case chatCloseButton
-    @available(*, deprecated, message: "use CALayerConstant.ninchatChatCloseButton")
+    @available(*, deprecated, message: "use CALayerConstant.ninchatChatCloseEmptyButton")
     case chatCloseButtonEmpty
     @available(*, deprecated, message: "use CALayerConstant.ninchatChatCloseButton")
     case iconChatCloseButton
@@ -167,9 +167,9 @@ public enum ColorConstants {
     case chatBubbleRightLink
     @available(*, deprecated, renamed: "ninchatColorModalTitleText")
     case modalText
-    @available(*, deprecated, message: "use CALayerConstant.ninchatModal")
+    @available(*, deprecated, message: "use CALayerConstant.ninchatModalTop and CALayerConstant.ninchatModalBottom")
     case modalBackground
-    @available(*, deprecated, message: "use CALayerConstant.ninchatBackground")
+    @available(*, deprecated, message: "use CALayerConstant.ninchatBackgroundTop")
     case backgroundTop
     @available(*, deprecated, renamed: "ninchatColorTextTop")
     case textTop
@@ -177,7 +177,7 @@ public enum ColorConstants {
     case textBottom
     @available(*, deprecated, renamed: "ninchatColorLink")
     case link
-    @available(*, deprecated, message: "use CALayerConstant.ninchatBackground")
+    @available(*, deprecated, message: "use CALayerConstant.ninchatBackgroundBottom")
     case backgroundBottom
     @available(*, deprecated, renamed: "ninchatColorRatingPositiveText")
     case ratingPositiveText
@@ -197,9 +197,12 @@ public enum CALayerConstant {
     case ninchatChatBubbleLeftRepeated
     case ninchatChatBubbleRightRepeated
     case ninchatChatCloseButton
+    case ninchatChatCloseEmptyButton
     case ninchatTextareaSubmitButton
-    case ninchatModal
-    case ninchatBackground
+    case ninchatModalTop
+    case ninchatModalBottom
+    case ninchatBackgroundTop
+    case ninchatBackgroundBottom
     case ninchatQuestionnaireRadioSelected
     case ninchatQuestionnaireRadioUnselected
     case ninchatQuestionnaireCheckboxSelectedIndicator

--- a/NinchatSDKSwift/Implementations/Constants.swift
+++ b/NinchatSDKSwift/Implementations/Constants.swift
@@ -12,38 +12,103 @@ import UIKit
 /// Assets override keys
 public typealias NINImageAssetDictionary = [AssetConstants:UIImage]
 public enum AssetConstants {
+    case ninchatIconLoader
+    case ninchatIconChatWritingIndicator
+    case ninchatChatBackground
+    case ninchatChatAvatarRight
+    case ninchatChatAvatarLeft
+    case ninchatChatPlayVideo
+    case ninchatIconTextareaCamera
+    case ninchatIconTextareaAttachment
+    case ninchatIconDownload
+    case ninchatIconVideoToggleFull
+    case ninchatIconVideoToggleNormal
+    case ninchatIconVideoSoundOn
+    case ninchatIconVideoSoundOff
+    case ninchatIconVideoMicrophoneOn
+    case ninchatIconVideoMicrophoneOff
+    case ninchatIconVideoCameraOn
+    case ninchatIconVideoCameraOff
+    case ninchatIconVideoHangup
+    case ninchatIconRatingPositive
+    case ninchatIconRatingNeutral
+    case ninchatIconRatingNegative
+
+    /* DEPRECATED
+     * Use new keys above or CALayerConstant instead
+    */
+    @available(*, deprecated, renamed: "ninchatIconLoader")
     case iconLoader
-    case iconChatCloseButton
-    case iconRatingPositive
-    case iconRatingNeutral
-    case iconRatingNegative
-    case iconTextareaCamera
-    case iconTextareaAttachment
-    case iconDownload
-    case iconVideoToggleFull
-    case iconVideoToggleNormal
-    case iconVideoSoundOn
-    case iconVideoSoundOff
-    case iconVideoMicrophoneOn
-    case iconVideoMicrophoneOff
-    case iconVideoCameraOn
-    case iconVideoCameraOff
-    case iconVideoHangup
+    @available(*, deprecated, renamed: "ninchatIconChatWritingIndicator")
     case chatWritingIndicator
+    @available(*, deprecated, renamed: "ninchatChatBackground")
     case chatBackground
-    case chatCloseButton
-    case chatCloseButtonEmpty
-    case chatBubbleLeft
-    case chatBubbleLeftRepeated
-    case chatBubbleRight
-    case chatBubbleRightRepeated
-    case chatAvatarRight
-    case chatAvatarLeft
-    case chatPlayVideo
-    case textareaSubmitButton
+    @available(*, deprecated, message: "use CALayerConstant.ninchatPrimaryButton")
     case primaryButton
+    @available(*, deprecated, message: "use CALayerConstant.ninchatSecondaryButton")
     case secondaryButton
+    @available(*, deprecated, message: "use CALayerConstant.ninchatChatCloseButton")
+    case chatCloseButton
+    @available(*, deprecated, message: "use CALayerConstant.ninchatChatCloseButton")
+    case chatCloseButtonEmpty
+    @available(*, deprecated, message: "use CALayerConstant.ninchatChatCloseButton")
+    case iconChatCloseButton
+    @available(*, deprecated, message: "use CALayerConstant.ninchatChatBubbleLeft")
+    case chatBubbleLeft
+    @available(*, deprecated, message: "use CALayerConstant.ninchatChatBubbleLeftRepeated")
+    case chatBubbleLeftRepeated
+    @available(*, deprecated, message: "use CALayerConstant.ninchatChatBubbleRight")
+    case chatBubbleRight
+    @available(*, deprecated, message: "use CALayerConstant.ninchatChatBubbleRightRepeated")
+    case chatBubbleRightRepeated
+    @available(*, deprecated, renamed: "ninchatChatAvatarRight")
+    case chatAvatarRight
+    @available(*, deprecated, renamed: "ninchatChatAvatarLeft")
+    case chatAvatarLeft
+    @available(*, deprecated, renamed: "ninchatChatPlayVideo")
+    case chatPlayVideo
+    @available(*, deprecated, renamed: "ninchatIconTextareaCamera")
+    case iconTextareaCamera
+    @available(*, deprecated, renamed: "ninchatIconTextareaAttachment")
+    case iconTextareaAttachment
+    @available(*, deprecated, renamed: "ninchatIconDownload")
+    case iconDownload
+    @available(*, deprecated, message: "use CALayerConstant.ninchatTextareaSubmitButton")
+    case textareaSubmitButton
+    @available(*, deprecated, renamed: "ninchatIconVideoToggleFull")
+    case iconVideoToggleFull
+    @available(*, deprecated, renamed: "ninchatIconVideoToggleNormal")
+    case iconVideoToggleNormal
+    @available(*, deprecated, renamed: "ninchatIconVideoSoundOn")
+    case iconVideoSoundOn
+    @available(*, deprecated, renamed: "ninchatIconVideoSoundOff")
+    case iconVideoSoundOff
+    @available(*, deprecated, renamed: "ninchatIconVideoMicrophoneOn")
+    case iconVideoMicrophoneOn
+    @available(*, deprecated, renamed: "ninchatIconVideoMicrophoneOff")
+    case iconVideoMicrophoneOff
+    @available(*, deprecated, renamed: "ninchatIconVideoCameraOn")
+    case iconVideoCameraOn
+    @available(*, deprecated, renamed: "ninchatIconVideoCameraOff")
+    case iconVideoCameraOff
+    @available(*, deprecated, renamed: "ninchatIconVideoHangup")
+    case iconVideoHangup
+    @available(*, deprecated, renamed: "ninchatIconRatingPositive")
+    case iconRatingPositive
+    @available(*, deprecated, renamed: "ninchatIconRatingNeutral")
+    case iconRatingNeutral
+    @available(*, deprecated, renamed: "ninchatIconRatingNegative")
+    case iconRatingNegative
+
+
+    @available(*, deprecated, message: "use QuestionnaireAssetConstants.questionnaireBackground")
     case questionnaireBackground
+    /*
+     * ninchat_icon_textarea_submit_button
+     * ninchat_ui_compose_select_button
+     * ninchat_ui_compose_select_button_selected
+     * ninchat_ui_compose_select_submit
+     */
 }
 
 /// Color override keys
@@ -81,6 +146,12 @@ public enum ColorConstants {
 public typealias NINLayerAssetDictionary = [CALayerConstant:CALayer]
 public let LAYER_NAME = "_ninchat-asset"
 public enum CALayerConstant {
+    case ninchatPrimaryButton
+    case ninchatSecondaryButton
+    case ninchatChatBubbleLeft
+    case ninchatChatBubbleRight
+    case ninchatChatBubbleLeftRepeated
+    case ninchatChatBubbleRightRepeated
     case ninchatChatCloseButton
     case ninchatTextareaSubmitButton
 }
@@ -117,6 +188,11 @@ public enum QuestionnaireColorConstants {
     case navigationBackText     /// Text and border color for the back button
     case navigationNextBackground   /// Background color for the next button
     case navigationBackBackground   /// Background color for the back button
+}
+
+public enum QuestionnaireAssetConstants {
+    /// Background image
+    case questionnaireBackground
 }
 
 

--- a/NinchatSDKSwift/Implementations/Constants.swift
+++ b/NinchatSDKSwift/Implementations/Constants.swift
@@ -114,31 +114,83 @@ public enum AssetConstants {
 /// Color override keys
 public typealias NINColorAssetDictionary = [ColorConstants:UIColor]
 public enum ColorConstants {
+    case ninchatColorButtonPrimaryText
+    case ninchatColorButtonSecondaryText
+    case ninchatColorInfoText
+    case ninchatColorChatName
+    case ninchatColorChatTimestamp
+    case ninchatColorChatBubbleLeftText
+    case ninchatColorChatBubbleRightText
+    case ninchatColorChatBubbleLeftTint
+    case ninchatColorChatBubbleRightTint
+    case ninchatColorTextareaText
+    case ninchatColorTextareaPlaceholder
+    case ninchatColorTextareaSubmitText
+    case ninchatColorChatBubbleLeftLink
+    case ninchatColorChatBubbleRightLink
+    case ninchatColorModalTitleText
+    case ninchatColorTextTop
+    case ninchatColorTextBottom
+    case ninchatColorLink
+    case ninchatColorRatingPositiveText
+    case ninchatColorRatingNeutralText
+    case ninchatColorRatingNegativeText
+
+
+    /* DEPRECATED
+     * Use new keys above or CALayerConstant instead
+    */
+    @available(*, deprecated, renamed: "ninchatColorButtonPrimaryText")
     case buttonPrimaryText
+    @available(*, deprecated, renamed: "ninchatColorButtonSecondaryText")
     case buttonSecondaryText
+    @available(*, deprecated, renamed: "ninchatColorInfoText")
     case infoText
+    @available(*, deprecated, renamed: "ninchatColorChatName")
     case chatName
+    @available(*, deprecated, renamed: "ninchatColorChatTimestamp")
     case chatTimestamp
+    @available(*, deprecated, renamed: "ninchatColorChatBubbleLeftText")
     case chatBubbleLeftText
+    @available(*, deprecated, renamed: "ninchatColorChatBubbleRightText")
     case chatBubbleRightText
+    @available(*, deprecated, renamed: "ninchatColorChatBubbleLeftTint")
     case chatBubbleLeftTint
+    @available(*, deprecated, renamed: "ninchatColorChatBubbleRightTint")
     case chatBubbleRightTint
+    @available(*, deprecated, message: "use CALayerConstant.ninchatChatCloseButton")
     case chatCloseButtonBackground
+    @available(*, deprecated, renamed: "ninchatColorTextareaText")
     case textareaText
+    @available(*, deprecated, message: "use CALayerConstant.ninchatTextareaSubmitButton")
     case textareaSubmit
+    @available(*, deprecated, renamed: "ninchatColorTextareaSubmitText")
     case textareaSubmitText
+    @available(*, deprecated, renamed: "ninchatColorTextareaPlaceholder")
     case textareaPlaceholder
+    @available(*, deprecated, renamed: "ninchatColorChatBubbleLeftLink")
     case chatBubbleLeftLink
+    @available(*, deprecated, renamed: "ninchatColorChatBubbleRightLink")
     case chatBubbleRightLink
+    @available(*, deprecated, renamed: "ninchatColorModalTitleText")
     case modalText
+    @available(*, deprecated, message: "use CALayerConstant.ninchatModal")
     case modalBackground
+    @available(*, deprecated, message: "use CALayerConstant.ninchatBackground")
     case backgroundTop
+    @available(*, deprecated, renamed: "ninchatColorTextTop")
     case textTop
+    @available(*, deprecated, renamed: "ninchatColorTextBottom")
     case textBottom
+    @available(*, deprecated, renamed: "ninchatColorLink")
     case link
+    @available(*, deprecated, message: "use CALayerConstant.ninchatBackground")
     case backgroundBottom
+    @available(*, deprecated, renamed: "ninchatColorRatingPositiveText")
     case ratingPositiveText
+    @available(*, deprecated, renamed: "ninchatColorRatingNeutralText")
     case ratingNeutralText
+    @available(*, deprecated, renamed: "ninchatColorRatingNegativeText")
     case ratingNegativeText
 }
 
@@ -154,6 +206,8 @@ public enum CALayerConstant {
     case ninchatChatBubbleRightRepeated
     case ninchatChatCloseButton
     case ninchatTextareaSubmitButton
+    case ninchatModal
+    case ninchatBackground
 }
 
 /// Questionnaire override keys

--- a/NinchatSDKSwift/Implementations/Constants.swift
+++ b/NinchatSDKSwift/Implementations/Constants.swift
@@ -208,47 +208,75 @@ public enum CALayerConstant {
     case ninchatTextareaSubmitButton
     case ninchatModal
     case ninchatBackground
+    case ninchatQuestionnaireRadioSelected
+    case ninchatQuestionnaireRadioUnselected
+    case ninchatQuestionnaireCheckboxSelectedIndicator
+    case ninchatQuestionnaireCheckboxUnselectedIndicator
+    case ninchatQuestionnaireSelectSelected
+    case ninchatQuestionnaireUnselectSelected
+    case ninchatQuestionnaireNavigationNext
+    case ninchatQuestionnaireNavigationBack
 }
 
 /// Questionnaire override keys
 public typealias NINQuestionnaireDictionary = [QuestionnaireColorConstants:String]
 public enum QuestionnaireColorConstants {
-    /// Title
+    case ninchatQuestionnaireColorTitleText
+    case ninchatQuestionnaireColorTextInput
+    case ninchatQuestionnaireColorRadioSelectedText
+    case ninchatQuestionnaireColorRadioUnselectedText
+    case ninchatQuestionnaireColorCheckboxSelectedText
+    case ninchatQuestionnaireColorCheckboxUnselectedText
+    case ninchatQuestionnaireColorSelectSelectedText
+    case ninchatQuestionnaireColorSelectUnselectText
+    case ninchatQuestionnaireColorNavigationNextText
+    case ninchatQuestionnaireColorNavigationBackText
+
+    /* DEPRECATED
+     * Use new keys above or CALayerConstant instead
+    */
+    @available(*, deprecated, renamed: "ninchatQuestionnaireColorTitleText")
     case titleTextColor
-
-    /// Input
-    case textInputColor     /// Text color for all inputs
-
-    /// Radio
-    case radioPrimaryText   /// Text color for selected elements
-    case radioSecondaryText /// Text color for deselected elements
-    case radioPrimaryBackground     /// Background color for selected elements
-    case radioSecondaryBackground   /// Background color for deselected elements
-
-    /// Checkbox
-    case checkboxPrimaryText    /// Text color for selected elements
-    case checkboxSecondaryText  /// Text color for deselected elements
-    case checkboxSelectedIndicator      /// Tint and border color for selected element's indicator
-    case checkboxDeselectedIndicator    /// Tint and border color for deselected element's indicator
-
-    /// Select
-    case selectSelectedText /// Text, indicator, and border color for selected state
-    case selectNormalText   /// Text, indicator, and border color for normal state
-    case selectSelectedBackground   /// Background color for selected state
-    case selectDeselectedBackground /// Background color for deselected state
-
-    /// Navigation
-    case navigationNextText     /// Text and border color for the next button
-    case navigationBackText     /// Text and border color for the back button
-    case navigationNextBackground   /// Background color for the next button
-    case navigationBackBackground   /// Background color for the back button
+    @available(*, deprecated, renamed: "ninchatQuestionnaireColorTextInput")
+    case textInputColor
+    @available(*, deprecated, renamed: "ninchatQuestionnaireColorRadioSelectedText")
+    case radioPrimaryText
+    @available(*, deprecated, renamed: "ninchatQuestionnaireColorRadioUnselectedText")
+    case radioSecondaryText
+    @available(*, deprecated, message: "use CALayerConstant.ninchatQuestionnaireRadioSelected")
+    case radioPrimaryBackground
+    @available(*, deprecated, message: "use CALayerConstant.ninchatQuestionnaireRadioUnselected")
+    case radioSecondaryBackground
+    @available(*, deprecated, renamed: "ninchatQuestionnaireColorCheckboxSelectedText")
+    case checkboxPrimaryText
+    @available(*, deprecated, renamed: "ninchatQuestionnaireColorCheckboxUnselectedText")
+    case checkboxSecondaryText
+    @available(*, deprecated, message: "use CALayerConstant.ninchatQuestionnaireCheckboxSelectedIndicator")
+    case checkboxSelectedIndicator
+    @available(*, deprecated, message: "use CALayerConstant.ninchatQuestionnaireCheckboxUnselectedIndicator")
+    case checkboxDeselectedIndicator
+    @available(*, deprecated, renamed: "ninchatQuestionnaireColorSelectSelectedText")
+    case selectSelectedText
+    @available(*, deprecated, renamed: "ninchatQuestionnaireColorSelectUnselectText")
+    case selectNormalText
+    @available(*, deprecated, message: "use CALayerConstant.ninchatQuestionnaireSelectSelected")
+    case selectSelectedBackground
+    @available(*, deprecated, message: "use CALayerConstant.ninchatQuestionnaireUnselectSelected")
+    case selectDeselectedBackground
+    @available(*, deprecated, renamed: "ninchatQuestionnaireColorNavigationNextText")
+    case navigationNextText
+    @available(*, deprecated, renamed: "ninchatQuestionnaireColorNavigationBackText")
+    case navigationBackText
+    @available(*, deprecated, message: "use CALayerConstant.ninchatQuestionnaireNavigationNext")
+    case navigationNextBackground
+    @available(*, deprecated, message: "use CALayerConstant.ninchatQuestionnaireNavigationBack")
+    case navigationBackBackground
 }
 
 public enum QuestionnaireAssetConstants {
     /// Background image
     case questionnaireBackground
 }
-
 
 // MARK: - Constants used within the SDK
 

--- a/NinchatSDKSwift/Implementations/Extensions/UIResponder+Extension.swift
+++ b/NinchatSDKSwift/Implementations/Extensions/UIResponder+Extension.swift
@@ -1,0 +1,18 @@
+//
+// Copyright (c) 7.4.2021 Somia Reality Oy. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+import UIKit
+
+protocol HasCustomLayer {
+    func applyLayerOverride(view: UIView)
+}
+extension HasCustomLayer where Self:UIResponder {
+    func applyLayerOverride(view: UIView) {
+        view.layer.sublayers?.filter({ $0.name == LAYER_NAME }).forEach({
+            $0.frame = view.bounds
+        })
+    }
+}

--- a/NinchatSDKSwift/Implementations/Extensions/UIView+Extension.swift
+++ b/NinchatSDKSwift/Implementations/Extensions/UIView+Extension.swift
@@ -93,11 +93,3 @@ extension UIView {
         }
     }
 }
-
-extension UIView {
-    static func applyLayerOverride(view: UIView) {
-        view.layer.sublayers?.filter({ $0.name == LAYER_NAME }).forEach({
-            $0.frame = view.bounds
-        })
-    }
-}

--- a/NinchatSDKSwift/Implementations/Managers/NINChatSession Internal/NINChatSessionInternal.swift
+++ b/NinchatSDKSwift/Implementations/Managers/NINChatSession Internal/NINChatSessionInternal.swift
@@ -142,7 +142,25 @@ struct InternalDelegate: NINChatSessionInternalDelegate {
     
     internal func override(questionnaireAsset key: QuestionnaireColorConstants) -> UIColor? {
         guard let session = self.session else { return nil }
-        return session.delegate?.ninchat(session, overrideQuestionnaireColorAssetKey: key)
+
+        /// TODO: REMOVE legacy keys
+        let deprecatedKeys: [QuestionnaireColorConstants:QuestionnaireColorConstants] = [
+            .ninchatQuestionnaireColorTitleText: .titleTextColor,
+            .ninchatQuestionnaireColorTextInput: .textInputColor,
+            .ninchatQuestionnaireColorRadioSelectedText: .radioPrimaryText,
+            .ninchatQuestionnaireColorRadioUnselectedText: .radioSecondaryText,
+            .ninchatQuestionnaireColorCheckboxSelectedText: .checkboxPrimaryText,
+            .ninchatQuestionnaireColorCheckboxUnselectedText: .checkboxSecondaryText,
+            .ninchatQuestionnaireColorSelectSelectedText: .selectSelectedText,
+            .ninchatQuestionnaireColorSelectUnselectText: .selectNormalText,
+            .ninchatQuestionnaireColorNavigationNextText: .navigationNextText,
+            .ninchatQuestionnaireColorNavigationBackText: .navigationBackText,
+        ]
+
+        if let color = session.delegate?.ninchat(session, overrideQuestionnaireColorAssetKey: key) {
+            return color
+        }
+        return session.delegate?.ninchat(session, overrideQuestionnaireColorAssetKey: deprecatedKeys[key]!)
     }
 }
 

--- a/NinchatSDKSwift/Implementations/Managers/NINChatSession Internal/NINChatSessionInternal.swift
+++ b/NinchatSDKSwift/Implementations/Managers/NINChatSession Internal/NINChatSessionInternal.swift
@@ -158,6 +158,10 @@ struct InternalDelegate: NINChatSessionInternalDelegate {
             .ninchatQuestionnaireColorSelectUnselectText: .selectNormalText,
             .ninchatQuestionnaireColorNavigationNextText: .navigationNextText,
             .ninchatQuestionnaireColorNavigationBackText: .navigationBackText,
+            .ninchatQuestionnaireCheckboxSelectedIndicator: .checkboxSelectedIndicator,
+            .ninchatQuestionnaireCheckboxUnselectedIndicator: .checkboxDeselectedIndicator,
+            .ninchatQuestionnaireSelectSelected: .selectSelectedBackground,
+            .ninchatQuestionnaireSelectUnselected: .selectDeselectedBackground
         ]
 
         if let color = session.delegate?.ninchat(session, overrideQuestionnaireColorAssetKey: key) {

--- a/NinchatSDKSwift/Implementations/Managers/NINChatSession Internal/NINChatSessionInternal.swift
+++ b/NinchatSDKSwift/Implementations/Managers/NINChatSession Internal/NINChatSessionInternal.swift
@@ -89,7 +89,8 @@ struct InternalDelegate: NINChatSessionInternalDelegate {
             .ninchatIconVideoHangup: .iconVideoHangup,
             .ninchatIconRatingPositive: .iconRatingPositive,
             .ninchatIconRatingNeutral: .iconRatingNeutral,
-            .ninchatIconRatingNegative: .iconRatingNegative
+            .ninchatIconRatingNegative: .iconRatingNegative,
+            .ninchatQuestionnaireBackground: .questionnaireBackground
         ]
 
         if let asset = session.delegate?.ninchat(session, overrideImageAssetForKey: key) {

--- a/NinchatSDKSwift/Implementations/Managers/NINChatSession Internal/NINChatSessionInternal.swift
+++ b/NinchatSDKSwift/Implementations/Managers/NINChatSession Internal/NINChatSessionInternal.swift
@@ -172,16 +172,11 @@ struct InternalDelegate: NINChatSessionInternalDelegate {
 extension NINChatSessionInternalDelegate {
     var imageAssetsDictionary: NINImageAssetDictionary {
         let userTypingIndicator = self.override(imageAsset: .ninchatIconChatWritingIndicator) ?? UIImage.animatedImage(with: [Int](0...23).compactMap({ UIImage(named: "icon_writing_\($0)", in: .SDKBundle, compatibleWith: nil) }), duration: 1.0)
-        let leftSideBubble = self.override(imageAsset: .chatBubbleLeft) ?? UIImage(named: "chat_bubble_left", in: .SDKBundle, compatibleWith: nil)
-        let leftSideBubbleSeries = self.override(imageAsset: .chatBubbleLeftRepeated) ?? UIImage(named: "chat_bubble_left_series", in: .SDKBundle, compatibleWith: nil)
-        let rightSideBubble = self.override(imageAsset: .chatBubbleRight) ?? UIImage(named: "chat_bubble_right", in: .SDKBundle, compatibleWith: nil)
-        let rightSideBubbleSeries = self.override(imageAsset: .chatBubbleRightRepeated) ?? UIImage(named: "chat_bubble_right_series", in: .SDKBundle, compatibleWith: nil)
         let leftSideAvatar = self.override(imageAsset: .ninchatChatAvatarLeft) ?? UIImage(named: "icon_avatar_other", in: .SDKBundle, compatibleWith: nil)
         let rightSideAvatar = self.override(imageAsset: .ninchatChatAvatarRight) ?? UIImage(named: "icon_avatar_mine", in: .SDKBundle, compatibleWith: nil)
         let playVideoIcon = self.override(imageAsset: .ninchatChatPlayVideo) ?? UIImage(named: "icon_play", in: .SDKBundle, compatibleWith: nil)
 
-        return [.ninchatIconChatWritingIndicator: userTypingIndicator!, .chatBubbleLeft: leftSideBubble!, .chatBubbleLeftRepeated: leftSideBubbleSeries!,
-                .chatBubbleRight: rightSideBubble!, .chatBubbleRightRepeated: rightSideBubbleSeries!, .ninchatChatAvatarLeft: leftSideAvatar!,
+        return [.ninchatIconChatWritingIndicator: userTypingIndicator!, .ninchatChatAvatarLeft: leftSideAvatar!,
                 .ninchatChatAvatarRight: rightSideAvatar!, .ninchatChatPlayVideo: playVideoIcon!]
     }
 

--- a/NinchatSDKSwift/Implementations/Managers/NINChatSession Internal/NINChatSessionInternal.swift
+++ b/NinchatSDKSwift/Implementations/Managers/NINChatSession Internal/NINChatSessionInternal.swift
@@ -96,7 +96,8 @@ struct InternalDelegate: NINChatSessionInternalDelegate {
         if let asset = session.delegate?.ninchat(session, overrideImageAssetForKey: key) {
             return asset
         }
-        return session.delegate?.ninchat(session, overrideImageAssetForKey: deprecatedKeys[key]!)
+        guard let depKey = deprecatedKeys[key] else { return nil }
+        return session.delegate?.ninchat(session, overrideImageAssetForKey: depKey)
     }
     
     internal func override(colorAsset key: ColorConstants) -> UIColor? {
@@ -130,7 +131,8 @@ struct InternalDelegate: NINChatSessionInternalDelegate {
         if let color = session.delegate?.ninchat(session, overrideColorAssetForKey: key) {
             return color
         }
-        return session.delegate?.ninchat(session, overrideColorAssetForKey: deprecatedKeys[key]!)
+        guard let depKey = deprecatedKeys[key] else { return nil }
+        return session.delegate?.ninchat(session, overrideColorAssetForKey: depKey)
     }
 
     internal func override(layerAsset key: CALayerConstant) -> CALayer? {
@@ -161,7 +163,8 @@ struct InternalDelegate: NINChatSessionInternalDelegate {
         if let color = session.delegate?.ninchat(session, overrideQuestionnaireColorAssetKey: key) {
             return color
         }
-        return session.delegate?.ninchat(session, overrideQuestionnaireColorAssetKey: deprecatedKeys[key]!)
+        guard let depKey = deprecatedKeys[key] else { return nil }
+        return session.delegate?.ninchat(session, overrideQuestionnaireColorAssetKey: depKey)
     }
 }
 

--- a/NinchatSDKSwift/Implementations/Managers/NINChatSession Internal/NINChatSessionInternal.swift
+++ b/NinchatSDKSwift/Implementations/Managers/NINChatSession Internal/NINChatSessionInternal.swift
@@ -66,7 +66,36 @@ struct InternalDelegate: NINChatSessionInternalDelegate {
 
     internal func override(imageAsset key: AssetConstants) -> UIImage? {
         guard let session = self.session else { return nil }
-        return session.delegate?.ninchat(session, overrideImageAssetForKey: key)
+
+        /// TODO: REMOVE legacy keys
+        let deprecatedKeys: [AssetConstants:AssetConstants] = [
+            .ninchatIconLoader: .iconLoader,
+            .ninchatIconChatWritingIndicator: .chatWritingIndicator,
+            .ninchatChatBackground: .chatBackground,
+            .ninchatChatAvatarRight: .chatAvatarRight,
+            .ninchatChatAvatarLeft: .chatAvatarLeft,
+            .ninchatChatPlayVideo: .chatPlayVideo,
+            .ninchatIconTextareaCamera: .iconTextareaCamera,
+            .ninchatIconTextareaAttachment: .iconTextareaAttachment,
+            .ninchatIconDownload: .iconDownload,
+            .ninchatIconVideoToggleFull: .iconVideoToggleFull,
+            .ninchatIconVideoToggleNormal: .iconVideoToggleNormal,
+            .ninchatIconVideoSoundOn: .iconVideoSoundOn,
+            .ninchatIconVideoSoundOff: .iconVideoSoundOff,
+            .ninchatIconVideoMicrophoneOn: .iconVideoMicrophoneOn,
+            .ninchatIconVideoMicrophoneOff: .iconVideoMicrophoneOff,
+            .ninchatIconVideoCameraOn: .iconVideoCameraOn,
+            .ninchatIconVideoCameraOff: .iconVideoCameraOff,
+            .ninchatIconVideoHangup: .iconVideoHangup,
+            .ninchatIconRatingPositive: .iconRatingPositive,
+            .ninchatIconRatingNeutral: .iconRatingNeutral,
+            .ninchatIconRatingNegative: .iconRatingNegative
+        ]
+
+        if let asset = session.delegate?.ninchat(session, overrideImageAssetForKey: key) {
+            return asset
+        }
+        return session.delegate?.ninchat(session, overrideImageAssetForKey: deprecatedKeys[key]!)
     }
     
     internal func override(colorAsset key: ColorConstants) -> UIColor? {
@@ -91,18 +120,18 @@ struct InternalDelegate: NINChatSessionInternalDelegate {
 /// Dictionaries for typing/loading cells
 extension NINChatSessionInternalDelegate {
     var imageAssetsDictionary: NINImageAssetDictionary {
-        let userTypingIndicator = self.override(imageAsset: .chatWritingIndicator) ?? UIImage.animatedImage(with: [Int](0...23).compactMap({ UIImage(named: "icon_writing_\($0)", in: .SDKBundle, compatibleWith: nil) }), duration: 1.0)
+        let userTypingIndicator = self.override(imageAsset: .ninchatIconChatWritingIndicator) ?? UIImage.animatedImage(with: [Int](0...23).compactMap({ UIImage(named: "icon_writing_\($0)", in: .SDKBundle, compatibleWith: nil) }), duration: 1.0)
         let leftSideBubble = self.override(imageAsset: .chatBubbleLeft) ?? UIImage(named: "chat_bubble_left", in: .SDKBundle, compatibleWith: nil)
         let leftSideBubbleSeries = self.override(imageAsset: .chatBubbleLeftRepeated) ?? UIImage(named: "chat_bubble_left_series", in: .SDKBundle, compatibleWith: nil)
         let rightSideBubble = self.override(imageAsset: .chatBubbleRight) ?? UIImage(named: "chat_bubble_right", in: .SDKBundle, compatibleWith: nil)
         let rightSideBubbleSeries = self.override(imageAsset: .chatBubbleRightRepeated) ?? UIImage(named: "chat_bubble_right_series", in: .SDKBundle, compatibleWith: nil)
-        let leftSideAvatar = self.override(imageAsset: .chatAvatarLeft) ?? UIImage(named: "icon_avatar_other", in: .SDKBundle, compatibleWith: nil)
-        let rightSideAvatar = self.override(imageAsset: .chatAvatarRight) ?? UIImage(named: "icon_avatar_mine", in: .SDKBundle, compatibleWith: nil)
-        let playVideoIcon = self.override(imageAsset: .chatPlayVideo) ?? UIImage(named: "icon_play", in: .SDKBundle, compatibleWith: nil)
+        let leftSideAvatar = self.override(imageAsset: .ninchatChatAvatarLeft) ?? UIImage(named: "icon_avatar_other", in: .SDKBundle, compatibleWith: nil)
+        let rightSideAvatar = self.override(imageAsset: .ninchatChatAvatarRight) ?? UIImage(named: "icon_avatar_mine", in: .SDKBundle, compatibleWith: nil)
+        let playVideoIcon = self.override(imageAsset: .ninchatChatPlayVideo) ?? UIImage(named: "icon_play", in: .SDKBundle, compatibleWith: nil)
 
-        return [.chatWritingIndicator: userTypingIndicator!, .chatBubbleLeft: leftSideBubble!, .chatBubbleLeftRepeated: leftSideBubbleSeries!,
-                .chatBubbleRight: rightSideBubble!, .chatBubbleRightRepeated: rightSideBubbleSeries!, .chatAvatarLeft: leftSideAvatar!,
-                .chatAvatarRight: rightSideAvatar!, .chatPlayVideo: playVideoIcon!]
+        return [.ninchatIconChatWritingIndicator: userTypingIndicator!, .chatBubbleLeft: leftSideBubble!, .chatBubbleLeftRepeated: leftSideBubbleSeries!,
+                .chatBubbleRight: rightSideBubble!, .chatBubbleRightRepeated: rightSideBubbleSeries!, .ninchatChatAvatarLeft: leftSideAvatar!,
+                .ninchatChatAvatarRight: rightSideAvatar!, .ninchatChatPlayVideo: playVideoIcon!]
     }
 
     var colorAssetsDictionary: [ColorConstants:UIColor] {

--- a/NinchatSDKSwift/Implementations/Managers/NINChatSession Internal/NINChatSessionInternal.swift
+++ b/NinchatSDKSwift/Implementations/Managers/NINChatSession Internal/NINChatSessionInternal.swift
@@ -100,7 +100,36 @@ struct InternalDelegate: NINChatSessionInternalDelegate {
     
     internal func override(colorAsset key: ColorConstants) -> UIColor? {
         guard let session = self.session else { return nil }
-        return session.delegate?.ninchat(session, overrideColorAssetForKey: key)
+
+        /// TODO: REMOVE legacy keys
+        let deprecatedKeys: [ColorConstants:ColorConstants] = [
+            .ninchatColorButtonPrimaryText: .buttonPrimaryText,
+            .ninchatColorButtonSecondaryText: .buttonSecondaryText,
+            .ninchatColorInfoText: .infoText,
+            .ninchatColorChatName: .chatName,
+            .ninchatColorChatTimestamp: .chatTimestamp,
+            .ninchatColorChatBubbleLeftText: .chatBubbleLeftText,
+            .ninchatColorChatBubbleRightText: .chatBubbleRightText,
+            .ninchatColorChatBubbleLeftTint: .chatBubbleLeftTint,
+            .ninchatColorChatBubbleRightTint: .chatBubbleRightTint,
+            .ninchatColorTextareaText: .textareaText,
+            .ninchatColorTextareaSubmitText: .textareaSubmitText,
+            .ninchatColorTextareaPlaceholder: .textareaPlaceholder,
+            .ninchatColorChatBubbleLeftLink: .chatBubbleLeftLink,
+            .ninchatColorChatBubbleRightLink: .chatBubbleRightLink,
+            .ninchatColorModalTitleText: .modalText,
+            .ninchatColorTextTop: .textTop,
+            .ninchatColorTextBottom: .textBottom,
+            .ninchatColorLink: .link,
+            .ninchatColorRatingPositiveText: .ratingPositiveText,
+            .ninchatColorRatingNeutralText: .ratingNeutralText,
+            .ninchatColorRatingNegativeText: .ratingNegativeText
+        ]
+
+        if let color = session.delegate?.ninchat(session, overrideColorAssetForKey: key) {
+            return color
+        }
+        return session.delegate?.ninchat(session, overrideColorAssetForKey: deprecatedKeys[key]!)
     }
 
     internal func override(layerAsset key: CALayerConstant) -> CALayer? {
@@ -135,7 +164,7 @@ extension NINChatSessionInternalDelegate {
     }
 
     var colorAssetsDictionary: [ColorConstants:UIColor] {
-        let colorKeys: [ColorConstants] = [.infoText, .chatName, .chatTimestamp, .chatBubbleLeftText, .chatBubbleLeftTint, .chatBubbleRightText, .chatBubbleRightTint, .chatBubbleLeftLink, .chatBubbleRightLink]
+        let colorKeys: [ColorConstants] = [.ninchatColorInfoText, .ninchatColorChatName, .ninchatColorChatTimestamp, .ninchatColorChatBubbleLeftText, .ninchatColorChatBubbleLeftTint, .ninchatColorChatBubbleRightText, .ninchatColorChatBubbleRightTint, .ninchatColorChatBubbleLeftLink, .ninchatColorChatBubbleRightLink]
         return colorKeys.compactMap({ ($0, self.override(colorAsset: $0)) }).reduce(into: [:]) { (colorAsset: inout [ColorConstants:UIColor], tuple: (key: ColorConstants, color: UIColor?)) in
             colorAsset[tuple.key] = tuple.color
         }

--- a/NinchatSDKSwift/Implementations/View/Chat.storyboard
+++ b/NinchatSDKSwift/Implementations/View/Chat.storyboard
@@ -17,13 +17,13 @@
         <!--Queue View Controller-->
         <scene sceneID="KNa-t7-ctL">
             <objects>
-                <viewController storyboardIdentifier="NINQueueViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="XUt-Du-Jff" customClass="NINQueueViewController" customModule="NinchatSwiftSDKUI" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="NINQueueViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="XUt-Du-Jff" customClass="NINQueueViewController" customModule="NinchatSDKSwift" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Uao-Kk-UXV">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cVi-ux-Foo" userLabel="Top content view">
-                                <rect key="frame" x="0.0" y="44" width="375" height="256.66666666666669"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="256.66666666666669"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon_progress_whirl" translatesAutoresizingMaskIntoConstraints="NO" id="9Zh-Yi-kTD">
                                         <rect key="frame" x="162.66666666666666" y="70" width="50" height="50"/>
@@ -54,7 +54,7 @@ you are next.</string>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dkT-tD-Ztq" userLabel="Bottom content view">
-                                <rect key="frame" x="0.0" y="300.66666666666674" width="375" height="477.33333333333326"/>
+                                <rect key="frame" x="0.0" y="256.66666666666669" width="375" height="555.33333333333326"/>
                                 <subviews>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed " textAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="RGm-bx-l81">
                                         <rect key="frame" x="20" y="50" width="335" height="56.333333333333343"/>
@@ -86,8 +86,8 @@ you are next.</string>
                             <constraint firstItem="yzb-y7-ihz" firstAttribute="trailing" secondItem="dkT-tD-Ztq" secondAttribute="trailing" id="DfQ-9P-pYT"/>
                             <constraint firstItem="cVi-ux-Foo" firstAttribute="leading" secondItem="yzb-y7-ihz" secondAttribute="leading" id="X7w-6Q-z6Z"/>
                             <constraint firstItem="cVi-ux-Foo" firstAttribute="trailing" secondItem="yzb-y7-ihz" secondAttribute="trailing" id="dR2-V7-RCJ"/>
-                            <constraint firstItem="cVi-ux-Foo" firstAttribute="top" secondItem="yzb-y7-ihz" secondAttribute="top" id="gFe-DM-y7a"/>
-                            <constraint firstItem="yzb-y7-ihz" firstAttribute="bottom" secondItem="dkT-tD-Ztq" secondAttribute="bottom" id="sHY-xV-w09"/>
+                            <constraint firstItem="cVi-ux-Foo" firstAttribute="top" secondItem="Uao-Kk-UXV" secondAttribute="top" id="gFe-DM-y7a"/>
+                            <constraint firstAttribute="bottom" secondItem="dkT-tD-Ztq" secondAttribute="bottom" id="sHY-xV-w09"/>
                             <constraint firstItem="dkT-tD-Ztq" firstAttribute="leading" secondItem="yzb-y7-ihz" secondAttribute="leading" id="wWz-ed-3zZ"/>
                         </constraints>
                     </view>
@@ -107,7 +107,7 @@ you are next.</string>
         <!--Chat View Controller-->
         <scene sceneID="5s0-Qq-Gee">
             <objects>
-                <viewController storyboardIdentifier="NINChatViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="bZ9-oP-wEd" customClass="NINChatViewController" customModule="NinchatSwiftSDKUI" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="NINChatViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="bZ9-oP-wEd" customClass="NINChatViewController" customModule="NinchatSDKSwift" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="wrn-IT-ZNh">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -118,7 +118,7 @@ you are next.</string>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RGh-Mv-yIb">
                                 <rect key="frame" x="0.0" y="44" width="375" height="734"/>
                                 <subviews>
-                                    <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="brw-f0-DOL" userLabel="Chat view" customClass="ChatView" customModule="NinchatSwiftSDKUI" customModuleProvider="target">
+                                    <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="brw-f0-DOL" userLabel="Chat view" customClass="ChatView" customModule="NinchatSDKSwift" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="614"/>
                                         <subviews>
                                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="g76-kj-vdH">
@@ -266,13 +266,13 @@ you are next.</string>
         <!--Rating View Controller-->
         <scene sceneID="AoA-TJ-9Dd">
             <objects>
-                <viewController storyboardIdentifier="NINRatingViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="sVb-C5-GLO" customClass="NINRatingViewController" customModule="NinchatSwiftSDKUI" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="NINRatingViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="sVb-C5-GLO" customClass="NINRatingViewController" customModule="NinchatSDKSwift" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="YOl-0M-h20">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="L5U-F0-l9Y" userLabel="Top part container view">
-                                <rect key="frame" x="0.0" y="44" width="375" height="406"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="406"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="qj1-1U-Y4U">
                                         <rect key="frame" x="16" y="65" width="343" height="276"/>
@@ -295,10 +295,10 @@ you are next.</string>
                                         </constraints>
                                     </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Zhu-12-0xh">
-                                        <rect key="frame" x="16" y="4" width="343" height="402"/>
+                                        <rect key="frame" x="16" y="44" width="343" height="362"/>
                                         <subviews>
                                             <view tag="1" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Vt6-hF-T0g" userLabel="Left avatar container">
-                                                <rect key="frame" x="15" y="0.0" width="35" height="402"/>
+                                                <rect key="frame" x="15" y="0.0" width="35" height="362"/>
                                                 <subviews>
                                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" image="icon_avatar_other" translatesAutoresizingMaskIntoConstraints="NO" id="Yfi-1D-cO5">
                                                         <rect key="frame" x="0.0" y="12" width="35" height="35"/>
@@ -317,10 +317,10 @@ you are next.</string>
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hb8-60-TGG">
-                                                <rect key="frame" x="58.000000000000007" y="9.6666666666666643" width="76.666666666666686" height="40"/>
+                                                <rect key="frame" x="57.999999999999993" y="9.6666666666666643" width="71.333333333333314" height="40"/>
                                                 <subviews>
                                                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="999" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Dr Koistinen" textAlignment="right" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vdr-sU-emu">
-                                                        <rect key="frame" x="0.0" y="11.666666666666663" width="76.666666666666671" height="16.333333333333329"/>
+                                                        <rect key="frame" x="0.0" y="11.000000000000009" width="71.333333333333329" height="17.666666666666671"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                                         <nil key="highlightedColor"/>
@@ -336,18 +336,18 @@ you are next.</string>
                                                 </constraints>
                                             </view>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="chat_bubble_left_series" translatesAutoresizingMaskIntoConstraints="NO" id="lpr-Ub-6OM">
-                                                <rect key="frame" x="15" y="55" width="313" height="55.333333333333343"/>
+                                                <rect key="frame" x="15" y="55" width="313" height="56.333333333333343"/>
                                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </imageView>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="How was our customer service?" translatesAutoresizingMaskIntoConstraints="NO" id="DbE-mm-dcs">
-                                                <rect key="frame" x="23" y="67" width="313" height="35.333333333333343"/>
+                                                <rect key="frame" x="23" y="67" width="313" height="36.333333333333343"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                                 <dataDetectorType key="dataDetectorTypes" phoneNumber="YES" link="YES"/>
                                             </textView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dEa-pc-H2B">
-                                                <rect key="frame" x="15" y="126.33333333333334" width="313" height="130.00000000000003"/>
+                                                <rect key="frame" x="15" y="127.33333333333334" width="313" height="130.00000000000003"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="130" id="PD8-mV-QrE"/>
@@ -376,9 +376,9 @@ you are next.</string>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstItem="qj1-1U-Y4U" firstAttribute="top" relation="greaterThanOrEqual" secondItem="L5U-F0-l9Y" secondAttribute="top" constant="4" id="3yh-j3-yC3"/>
+                                    <constraint firstItem="qj1-1U-Y4U" firstAttribute="top" relation="greaterThanOrEqual" secondItem="L5U-F0-l9Y" secondAttribute="top" constant="44" id="3yh-j3-yC3"/>
                                     <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="qj1-1U-Y4U" secondAttribute="bottom" id="6ME-kd-umm"/>
-                                    <constraint firstItem="Zhu-12-0xh" firstAttribute="top" secondItem="L5U-F0-l9Y" secondAttribute="top" constant="4" id="6gJ-xn-wen"/>
+                                    <constraint firstItem="Zhu-12-0xh" firstAttribute="top" secondItem="L5U-F0-l9Y" secondAttribute="top" constant="44" id="6gJ-xn-wen"/>
                                     <constraint firstItem="qj1-1U-Y4U" firstAttribute="leading" secondItem="L5U-F0-l9Y" secondAttribute="leading" constant="16" id="CIl-qa-20p"/>
                                     <constraint firstItem="qj1-1U-Y4U" firstAttribute="centerY" secondItem="L5U-F0-l9Y" secondAttribute="centerY" id="CsP-6S-1DP"/>
                                     <constraint firstAttribute="bottom" secondItem="Zhu-12-0xh" secondAttribute="bottom" id="OdD-X9-nCn"/>
@@ -404,7 +404,7 @@ you are next.</string>
                         <viewLayoutGuide key="safeArea" id="oWm-rW-0NV"/>
                         <color key="backgroundColor" red="0.9137254901960784" green="0.9137254901960784" blue="0.9137254901960784" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
-                            <constraint firstItem="L5U-F0-l9Y" firstAttribute="top" secondItem="oWm-rW-0NV" secondAttribute="top" id="484-Gt-Qg4"/>
+                            <constraint firstItem="L5U-F0-l9Y" firstAttribute="top" secondItem="YOl-0M-h20" secondAttribute="top" id="484-Gt-Qg4"/>
                             <constraint firstItem="L5U-F0-l9Y" firstAttribute="trailing" secondItem="oWm-rW-0NV" secondAttribute="trailing" id="6zw-zO-mF8"/>
                             <constraint firstItem="L5U-F0-l9Y" firstAttribute="leading" secondItem="oWm-rW-0NV" secondAttribute="leading" id="MIS-tu-hqe"/>
                             <constraint firstItem="oWm-rW-0NV" firstAttribute="bottom" secondItem="PLV-Oi-4sR" secondAttribute="bottom" constant="60" id="Nfl-pb-NbK"/>
@@ -435,13 +435,13 @@ you are next.</string>
         <!--Initial View Controller-->
         <scene sceneID="XHh-YP-k7w">
             <objects>
-                <viewController storyboardIdentifier="NINInitialViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="YpM-11-QhB" customClass="NINInitialViewController" customModule="NinchatSwiftSDKUI" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="NINInitialViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="YpM-11-QhB" customClass="NINInitialViewController" customModule="NinchatSDKSwift" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="w6e-s4-vNx">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Wa1-0U-Lj7" userLabel="Top container view">
-                                <rect key="frame" x="0.0" y="44" width="375" height="316.33333333333331"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="316.33333333333331"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wXY-o9-goJ" userLabel="Welcome text container view">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="136.33333333333334"/>
@@ -469,7 +469,7 @@ you are next.</string>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="kgP-Ty-5vY">
                                                 <rect key="frame" x="67.666666666666686" y="5" width="240" height="60"/>
                                                 <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mti-Jm-Fuc" customClass="Button" customModule="NinchatSwiftSDKUI" customModuleProvider="target">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mti-Jm-Fuc" customClass="Button" customModule="NinchatSDKSwift" customModuleProvider="target">
                                                         <rect key="frame" x="0.0" y="0.0" width="240" height="60"/>
                                                         <color key="backgroundColor" red="0.28627450980392155" green="0.67450980392156867" blue="0.99215686274509807" alpha="1" colorSpace="calibratedRGB"/>
                                                         <constraints>
@@ -500,8 +500,8 @@ you are next.</string>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                                 <dataDetectorType key="dataDetectorTypes" phoneNumber="YES" link="YES"/>
                                             </textView>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ign-ZR-Zu6" customClass="Button" customModule="NinchatSwiftSDKUI" customModuleProvider="target">
-                                                <rect key="frame" x="67.666666666666686" y="79.999999999999972" width="240" height="60"/>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ign-ZR-Zu6" customClass="Button" customModule="NinchatSDKSwift" customModuleProvider="target">
+                                                <rect key="frame" x="67.666666666666686" y="80" width="240" height="60"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="60" id="FmF-rn-Al0"/>
@@ -541,7 +541,7 @@ you are next.</string>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3xg-1C-FCR" userLabel="Bottom container view">
-                                <rect key="frame" x="0.0" y="360.33333333333326" width="375" height="417.66666666666674"/>
+                                <rect key="frame" x="0.0" y="316.33333333333326" width="375" height="495.66666666666674"/>
                                 <subviews>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="D4q-k8-gpN">
                                         <rect key="frame" x="20" y="40" width="335" height="137"/>
@@ -567,8 +567,8 @@ you are next.</string>
                             <constraint firstItem="3xg-1C-FCR" firstAttribute="top" secondItem="Wa1-0U-Lj7" secondAttribute="bottom" id="4T6-uF-e7I"/>
                             <constraint firstItem="R8Q-s8-woL" firstAttribute="trailing" secondItem="Wa1-0U-Lj7" secondAttribute="trailing" id="BA9-zs-Y4m"/>
                             <constraint firstItem="Wa1-0U-Lj7" firstAttribute="leading" secondItem="R8Q-s8-woL" secondAttribute="leading" id="Dmp-X2-LC5"/>
-                            <constraint firstItem="R8Q-s8-woL" firstAttribute="bottom" secondItem="3xg-1C-FCR" secondAttribute="bottom" id="GQU-M6-6le"/>
-                            <constraint firstItem="Wa1-0U-Lj7" firstAttribute="top" secondItem="R8Q-s8-woL" secondAttribute="top" id="TBb-F8-hd4"/>
+                            <constraint firstAttribute="bottom" secondItem="3xg-1C-FCR" secondAttribute="bottom" id="GQU-M6-6le"/>
+                            <constraint firstItem="Wa1-0U-Lj7" firstAttribute="top" secondItem="w6e-s4-vNx" secondAttribute="top" id="TBb-F8-hd4"/>
                             <constraint firstItem="R8Q-s8-woL" firstAttribute="trailing" secondItem="3xg-1C-FCR" secondAttribute="trailing" id="drz-l5-mNW"/>
                         </constraints>
                     </view>
@@ -591,7 +591,7 @@ you are next.</string>
         <!--Questionnaire View Controller-->
         <scene sceneID="aa4-SC-Gqp">
             <objects>
-                <viewController storyboardIdentifier="NINQuestionnaireViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="2fr-nW-Pce" customClass="NINQuestionnaireViewController" customModule="NinchatSwiftSDKUI" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="NINQuestionnaireViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="2fr-nW-Pce" customClass="NINQuestionnaireViewController" customModule="NinchatSDKSwift" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="4SI-g6-pAy">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/NinchatSDKSwift/Implementations/View/Chat.storyboard
+++ b/NinchatSDKSwift/Implementations/View/Chat.storyboard
@@ -295,10 +295,10 @@ you are next.</string>
                                         </constraints>
                                     </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Zhu-12-0xh">
-                                        <rect key="frame" x="16" y="44" width="343" height="362"/>
+                                        <rect key="frame" x="16" y="58" width="343" height="348"/>
                                         <subviews>
                                             <view tag="1" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Vt6-hF-T0g" userLabel="Left avatar container">
-                                                <rect key="frame" x="15" y="0.0" width="35" height="362"/>
+                                                <rect key="frame" x="15" y="0.0" width="35" height="348"/>
                                                 <subviews>
                                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" image="icon_avatar_other" translatesAutoresizingMaskIntoConstraints="NO" id="Yfi-1D-cO5">
                                                         <rect key="frame" x="0.0" y="12" width="35" height="35"/>
@@ -317,10 +317,10 @@ you are next.</string>
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hb8-60-TGG">
-                                                <rect key="frame" x="57.999999999999993" y="9.6666666666666643" width="71.333333333333314" height="40"/>
+                                                <rect key="frame" x="57.999999999999993" y="9.6666666666666714" width="71.333333333333314" height="40"/>
                                                 <subviews>
                                                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="999" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Dr Koistinen" textAlignment="right" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vdr-sU-emu">
-                                                        <rect key="frame" x="0.0" y="11.000000000000009" width="71.333333333333329" height="17.666666666666671"/>
+                                                        <rect key="frame" x="0.0" y="11.000000000000002" width="71.333333333333329" height="17.666666666666671"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                                         <nil key="highlightedColor"/>
@@ -378,7 +378,7 @@ you are next.</string>
                                 <constraints>
                                     <constraint firstItem="qj1-1U-Y4U" firstAttribute="top" relation="greaterThanOrEqual" secondItem="L5U-F0-l9Y" secondAttribute="top" constant="44" id="3yh-j3-yC3"/>
                                     <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="qj1-1U-Y4U" secondAttribute="bottom" id="6ME-kd-umm"/>
-                                    <constraint firstItem="Zhu-12-0xh" firstAttribute="top" secondItem="L5U-F0-l9Y" secondAttribute="top" constant="44" id="6gJ-xn-wen"/>
+                                    <constraint firstItem="Zhu-12-0xh" firstAttribute="top" secondItem="L5U-F0-l9Y" secondAttribute="top" constant="58" id="6gJ-xn-wen"/>
                                     <constraint firstItem="qj1-1U-Y4U" firstAttribute="leading" secondItem="L5U-F0-l9Y" secondAttribute="leading" constant="16" id="CIl-qa-20p"/>
                                     <constraint firstItem="qj1-1U-Y4U" firstAttribute="centerY" secondItem="L5U-F0-l9Y" secondAttribute="centerY" id="CsP-6S-1DP"/>
                                     <constraint firstAttribute="bottom" secondItem="Zhu-12-0xh" secondAttribute="bottom" id="OdD-X9-nCn"/>

--- a/NinchatSDKSwift/Implementations/View/UIKit/Button/Button.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Button/Button.swift
@@ -46,7 +46,7 @@ class Button: UIButton {
             self.layer.cornerRadius = 0
             self.layer.borderWidth = 0
         }
-        if let overrideColor = delegate?.override(colorAsset: primary ? .buttonPrimaryText : .buttonSecondaryText) {
+        if let overrideColor = delegate?.override(colorAsset: primary ? .ninchatColorButtonPrimaryText : .ninchatColorButtonSecondaryText) {
             self.setTitleColor(overrideColor, for: .normal)
         }
     }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Button/Button.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Button/Button.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-class Button: UIButton {
+class Button: UIButton, HasCustomLayer {
     var closure: ((Button) -> Void)?
     var type: QuestionnaireButtonType?
 
@@ -23,7 +23,12 @@ class Button: UIButton {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
-    
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        applyLayerOverride(view: self)
+    }
+
     // MARK: - User actions
     
     override func sendActions(for controlEvents: UIControl.Event) {
@@ -40,11 +45,19 @@ class Button: UIButton {
     
     func overrideAssets(with delegate: NINChatSessionInternalDelegate?, isPrimary primary: Bool) {
         self.titleLabel?.font = .ninchat
-        if let overrideImage = delegate?.override(imageAsset: primary ? .primaryButton : .secondaryButton) {
+        self.backgroundColor = .clear
+
+        if let layer = delegate?.override(layerAsset: primary ? .ninchatPrimaryButton : .ninchatSecondaryButton) {
+            self.layer.insertSublayer(layer, below: self.titleLabel?.layer)
+        }
+        /// TODO: REMOVE legacy delegate
+        else if let overrideImage = delegate?.override(imageAsset: primary ? .primaryButton : .secondaryButton) {
             self.setBackgroundImage(overrideImage, for: .normal)
-            self.backgroundColor = .clear
-            self.layer.cornerRadius = 0
-            self.layer.borderWidth = 0
+            self.roundButton()
+        } else {
+            self.setTitleColor(primary ? .white : .defaultBackgroundButton, for: .normal)
+            self.backgroundColor = primary ? .defaultBackgroundButton : .white
+            self.roundButton()
         }
         if let overrideColor = delegate?.override(colorAsset: primary ? .ninchatColorButtonPrimaryText : .ninchatColorButtonSecondaryText) {
             self.setTitleColor(overrideColor, for: .normal)

--- a/NinchatSDKSwift/Implementations/View/UIKit/Button/CloseButton.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Button/CloseButton.swift
@@ -88,7 +88,7 @@ final class CloseButton: UIView, CloseButtonProtocol {
         }
         
         /// Handle overriding the button text & border color
-        if let textColor = session?.override(colorAsset: .buttonSecondaryText) {
+        if let textColor = session?.override(colorAsset: .ninchatColorButtonSecondaryText) {
             self.theButton.setTitleColor(textColor, for: .normal)
             self.closeButtonImageView.tintColor = textColor
         }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Button/CloseButton.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Button/CloseButton.swift
@@ -13,7 +13,7 @@ protocol CloseButtonProtocol {
     func overrideAssets(with session: NINChatSessionInternalDelegate?)
 }
 
-final class CloseButton: UIView, CloseButtonProtocol {
+final class CloseButton: UIView, HasCustomLayer, CloseButtonProtocol {
     
     // MARK: - Outlets
     
@@ -41,7 +41,6 @@ final class CloseButton: UIView, CloseButtonProtocol {
             self.theButton.closure = closure
         }
     }
-    
     var buttonTitle: String! {
         didSet {
             self.theButton.setTitle(buttonTitle, for: .normal)
@@ -51,43 +50,44 @@ final class CloseButton: UIView, CloseButtonProtocol {
     
     override func layoutSubviews() {
         super.layoutSubviews()
-        UIView.applyLayerOverride(view: self)
+        applyLayerOverride(view: self)
     }
     
     func overrideAssets(with session: NINChatSessionInternalDelegate?) {
         self.theButton.titleLabel?.font = .ninchat
-        self.round(borderWidth: 1.0, borderColor: .defaultBackgroundButton)
-        self.backgroundColor = .white
+        self.backgroundColor = .clear
 
-        func shapeButton(image: UIImage) {
-            /// Overriding (setting) the button background image; no border.
-            self.theButton.setBackgroundImage(image, for: .normal)
-            self.theButton.contentMode = .scaleAspectFill
-            self.theButton.backgroundColor = .clear
-            self.theButton.layer.cornerRadius = 0
-            self.theButton.layer.borderWidth = 0
-        }
-
-        if let backgroundColor = session?.override(colorAsset: .chatCloseButtonBackground) {
-            self.backgroundColor = backgroundColor
-        }
-
-        if let layer = session?.override(layerAsset: .ninchatChatCloseButton) {
+        if buttonTitle.isEmpty, let layer = session?.override(layerAsset: .ninchatChatCloseEmptyButton) {
             self.layer.addSublayer(layer)
-        }
+        } else if let layer = session?.override(layerAsset: .ninchatChatCloseButton) {
+            self.layer.addSublayer(layer)
+        } else {
+            /// TODO: REMOVE legacy delegates
 
-        if buttonTitle.isEmpty, let overrideImage = session?.override(imageAsset: .chatCloseButtonEmpty) {
-            shapeButton(image: overrideImage)
-        } else if let overrideImage = session?.override(imageAsset: .chatCloseButton) {
-            shapeButton(image: overrideImage)
+            func shapeButton(image: UIImage) {
+                /// Overriding (setting) the button background image; no border.
+                self.theButton.setBackgroundImage(image, for: .normal)
+                self.theButton.contentMode = .scaleAspectFill
+                self.theButton.backgroundColor = .clear
+                self.theButton.layer.cornerRadius = 0
+                self.theButton.layer.borderWidth = 0
+            }
+
+            self.round(borderWidth: 1.0, borderColor: .defaultBackgroundButton)
+            self.backgroundColor = .white
+
+            if let backgroundColor = session?.override(colorAsset: .chatCloseButtonBackground) {
+                self.backgroundColor = backgroundColor
+            }
+            if buttonTitle.isEmpty, let overrideImage = session?.override(imageAsset: .chatCloseButtonEmpty) {
+                shapeButton(image: overrideImage)
+            } else if let overrideImage = session?.override(imageAsset: .chatCloseButton) {
+                shapeButton(image: overrideImage)
+            }
+            if let icon = session?.override(imageAsset: .iconChatCloseButton) {
+                self.closeButtonImageView.image = icon
+            }
         }
-        
-        /// Handle overriding the button icon image
-        if let icon = session?.override(imageAsset: .iconChatCloseButton) {
-            self.closeButtonImageView.image = icon
-        }
-        
-        /// Handle overriding the button text & border color
         if let textColor = session?.override(colorAsset: .ninchatColorButtonSecondaryText) {
             self.theButton.setTitleColor(textColor, for: .normal)
             self.closeButtonImageView.tintColor = textColor

--- a/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Channel Cell/ChatChannelCell.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Channel Cell/ChatChannelCell.swift
@@ -75,11 +75,11 @@ class ChatChannelCell: UITableViewCell, ChatCell, ChannelCell {
     
     /// Performs asset customizations independent of message sender
     internal func applyCommon(imageAssets: NINImageAssetDictionary?, colorAssets: NINColorAssetDictionary?) {
-        if let nameColor = colorAssets?[.chatName] {
+        if let nameColor = colorAssets?[.ninchatColorChatName] {
             self.senderNameLabel.textColor = nameColor
         }
         
-        if let timeColor = colorAssets?[.chatTimestamp] {
+        if let timeColor = colorAssets?[.ninchatColorChatTimestamp] {
             self.timeLabel.textColor = timeColor
         }
     }
@@ -129,7 +129,7 @@ class ChatChannelMineCell: ChatChannelCell {
         self.bubbleImageView.image = (series) ? imageAssets?[.chatBubbleRightRepeated] : imageAssets?[.chatBubbleRight]
         
         /// White text on black bubble
-        self.bubbleImageView.tintColor = colorAssets?[.chatBubbleRightTint] ?? .black
+        self.bubbleImageView.tintColor = colorAssets?[.ninchatColorChatBubbleRightTint] ?? .black
         if let name = config?.nameOverride, !name.isEmpty {
             self.senderNameLabel.text = name
         }
@@ -175,7 +175,7 @@ class ChatChannelOthersCell: ChatChannelCell {
         self.bubbleImageView.image = (series) ? imageAssets?[.chatBubbleLeftRepeated] : imageAssets?[.chatBubbleLeft]
         
         /// Black text on white bubble
-        self.bubbleImageView.tintColor = colorAssets?[.chatBubbleLeftTint] ?? .white
+        self.bubbleImageView.tintColor = colorAssets?[.ninchatColorChatBubbleLeftTint] ?? .white
         if let name = config?.nameOverride, !name.isEmpty {
             self.senderNameLabel.text = name
         }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Channel Cell/ChatChannelCell.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Channel Cell/ChatChannelCell.swift
@@ -129,7 +129,7 @@ class ChatChannelMineCell: ChatChannelCell {
         self.bubbleImageView.image = UIImage(named: (series) ? "chat_bubble_left_series" : "chat_bubble_left", in: .SDKBundle, compatibleWith: nil)
 
         /// White text on black bubble
-        self.bubbleImageView.tintColor = colorAssets?[.chatBubbleRightTint] ?? .black
+        self.bubbleImageView.tintColor = colorAssets?[.ninchatColorChatBubbleRightTint] ?? .black
         if let name = config?.nameOverride, !name.isEmpty {
             self.senderNameLabel.text = name
         }
@@ -175,7 +175,7 @@ class ChatChannelOthersCell: ChatChannelCell {
         self.bubbleImageView.image = UIImage(named: (series) ? "chat_bubble_right_series" : "chat_bubble_right", in: .SDKBundle, compatibleWith: nil)
         
         /// Black text on white bubble
-        self.bubbleImageView.tintColor = colorAssets?[.chatBubbleLeftTint] ?? .white
+        self.bubbleImageView.tintColor = colorAssets?[.ninchatColorChatBubbleLeftTint] ?? .white
         if let name = config?.nameOverride, !name.isEmpty {
             self.senderNameLabel.text = name
         }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Channel Cell/ChatChannelCell.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Channel Cell/ChatChannelCell.swift
@@ -126,8 +126,8 @@ class ChatChannelMineCell: ChatChannelCell {
     
     internal func configureMyMessage(avatar url: String?, imageAssets: NINImageAssetDictionary?, colorAssets: NINColorAssetDictionary?, config: AvatarConfig?, series: Bool) {
         self.senderNameLabel.textAlignment = .right
-        self.bubbleImageView.image = (series) ? imageAssets?[.chatBubbleRightRepeated] : imageAssets?[.chatBubbleRight]
-        
+        self.bubbleImageView.image = UIImage(named: (series) ? "chat_bubble_left_series" : "chat_bubble_left", in: .SDKBundle, compatibleWith: nil)
+
         /// White text on black bubble
         self.bubbleImageView.tintColor = colorAssets?[.chatBubbleRightTint] ?? .black
         if let name = config?.nameOverride, !name.isEmpty {
@@ -172,7 +172,7 @@ class ChatChannelOthersCell: ChatChannelCell {
     
     internal func configureOtherMessage(avatar url: String?, imageAssets: NINImageAssetDictionary?, colorAssets: NINColorAssetDictionary?, config: AvatarConfig?, series: Bool) {
         self.senderNameLabel.textAlignment = .left
-        self.bubbleImageView.image = (series) ? imageAssets?[.chatBubbleLeftRepeated] : imageAssets?[.chatBubbleLeft]
+        self.bubbleImageView.image = UIImage(named: (series) ? "chat_bubble_right_series" : "chat_bubble_right", in: .SDKBundle, compatibleWith: nil)
         
         /// Black text on white bubble
         self.bubbleImageView.tintColor = colorAssets?[.chatBubbleLeftTint] ?? .white

--- a/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Channel Cell/ChatChannelCell.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Channel Cell/ChatChannelCell.swift
@@ -79,7 +79,7 @@ class ChatChannelCell: UITableViewCell, ChatCell, ChannelCell {
             self.senderNameLabel.textColor = nameColor
         }
         
-        if let timeColor = colorAssets?[.ninchatColorChatTimestamp] {
+        if let timeColor = colorAssets?[.chatTimestamp] {
             self.timeLabel.textColor = timeColor
         }
     }
@@ -129,7 +129,7 @@ class ChatChannelMineCell: ChatChannelCell {
         self.bubbleImageView.image = (series) ? imageAssets?[.chatBubbleRightRepeated] : imageAssets?[.chatBubbleRight]
         
         /// White text on black bubble
-        self.bubbleImageView.tintColor = colorAssets?[.ninchatColorChatBubbleRightTint] ?? .black
+        self.bubbleImageView.tintColor = colorAssets?[.chatBubbleRightTint] ?? .black
         if let name = config?.nameOverride, !name.isEmpty {
             self.senderNameLabel.text = name
         }
@@ -175,7 +175,7 @@ class ChatChannelOthersCell: ChatChannelCell {
         self.bubbleImageView.image = (series) ? imageAssets?[.chatBubbleLeftRepeated] : imageAssets?[.chatBubbleLeft]
         
         /// Black text on white bubble
-        self.bubbleImageView.tintColor = colorAssets?[.ninchatColorChatBubbleLeftTint] ?? .white
+        self.bubbleImageView.tintColor = colorAssets?[.chatBubbleLeftTint] ?? .white
         if let name = config?.nameOverride, !name.isEmpty {
             self.senderNameLabel.text = name
         }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Channel Cell/ChatChannelTextCell.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Channel Cell/ChatChannelTextCell.swift
@@ -39,10 +39,10 @@ final class ChatChannelTextMineCell: ChatChannelMineCell, ChannelTextCell {
         self.messageTextView.textColor = .white
         self.messageTextView.textAlignment = .right
         self.messageTextView.linkTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.blue]
-        if let bubbleTextColor = colorAssets?[.chatBubbleRightText] {
+        if let bubbleTextColor = colorAssets?[.ninchatColorChatBubbleRightText] {
             self.messageTextView.textColor = bubbleTextColor
         }
-        if let linkColor = colorAssets?[.chatBubbleRightLink] {
+        if let linkColor = colorAssets?[.ninchatColorChatBubbleRightLink] {
             self.messageTextView.linkTextAttributes = [NSAttributedString.Key.foregroundColor: linkColor]
         }
         
@@ -63,10 +63,10 @@ final class ChatChannelTextOthersCell: ChatChannelOthersCell, ChannelTextCell {
         self.messageTextView.textAlignment = .left
         self.messageTextView.textColor = .black
         self.messageTextView.linkTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.blue]
-        if let bubbleTextColor = colorAssets?[.chatBubbleLeftText] {
+        if let bubbleTextColor = colorAssets?[.ninchatColorChatBubbleLeftText] {
             self.messageTextView.textColor = bubbleTextColor
         }
-        if let linkColor = colorAssets?[.chatBubbleLeftLink] {
+        if let linkColor = colorAssets?[.ninchatColorChatBubbleLeftLink] {
             self.messageTextView.linkTextAttributes = [NSAttributedString.Key.foregroundColor: linkColor]
         }
     }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Meta Cell/ChatMetaCell.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Meta Cell/ChatMetaCell.swift
@@ -42,7 +42,7 @@ final class ChatMetaCell: UITableViewCell, ChatMeta {
     }
     
     private func applyAssets(_ message: MetaMessage, _ colorAssets: NINColorAssetDictionary?) {
-        if let labelColor = colorAssets?[.infoText] {
+        if let labelColor = colorAssets?[.ninchatColorInfoText] {
             self.metaTextLabel.textColor = labelColor
         }
         if let title = message.closeChatButtonTitle {

--- a/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Typing Cell/ChatTypingCell.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Typing Cell/ChatTypingCell.swift
@@ -51,7 +51,7 @@ class ChatTypingCell: UITableViewCell {
             self.senderNameLabel.textColor = nameColor
         }
         
-        if let timeColor = colorAssets?[.ninchatColorChatTimestamp] {
+        if let timeColor = colorAssets?[.chatTimestamp] {
             self.timeLabel?.textColor = timeColor
         }
     }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Typing Cell/ChatTypingCell.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Typing Cell/ChatTypingCell.swift
@@ -47,11 +47,11 @@ class ChatTypingCell: UITableViewCell {
 
     /// Performs asset customizations independent of message sender
     private func applyCommon(imageAssets: NINImageAssetDictionary?, colorAssets: NINColorAssetDictionary?) {
-        if let nameColor = colorAssets?[.chatName] {
+        if let nameColor = colorAssets?[.ninchatColorChatName] {
             self.senderNameLabel.textColor = nameColor
         }
         
-        if let timeColor = colorAssets?[.chatTimestamp] {
+        if let timeColor = colorAssets?[.ninchatColorChatTimestamp] {
             self.timeLabel?.textColor = timeColor
         }
     }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Typing Cell/ChatTypingCell.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Typing Cell/ChatTypingCell.swift
@@ -79,7 +79,7 @@ extension ChatTypingCell: TypingCell {
 
         /// Make Image view background match the bubble color
         self.bubbleImageView.tintColor = .white
-        self.bubbleImageView.image = imageAssets?[.chatBubbleLeft]
+        self.bubbleImageView.image = UIImage(named: "chat_bubble_left", in: .SDKBundle, compatibleWith: nil)
 
         self.messageImageView.backgroundColor = .white
         self.messageImageView.image = imageAssets?[.ninchatIconChatWritingIndicator]
@@ -100,7 +100,7 @@ extension ChatTypingCell: LoadingCell {
 
         /// Make Image view background match the bubble color
         self.bubbleImageView.tintColor = .white
-        self.bubbleImageView.image = imageAssets?[.chatBubbleLeft]
+        self.bubbleImageView.image = UIImage(named: "chat_bubble_left", in: .SDKBundle, compatibleWith: nil)
 
         self.messageImageView.backgroundColor = .white
         self.messageImageView.image = imageAssets?[.ninchatIconChatWritingIndicator]

--- a/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Typing Cell/ChatTypingCell.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Typing Cell/ChatTypingCell.swift
@@ -82,7 +82,7 @@ extension ChatTypingCell: TypingCell {
         self.bubbleImageView.image = imageAssets?[.chatBubbleLeft]
 
         self.messageImageView.backgroundColor = .white
-        self.messageImageView.image = imageAssets?[.chatWritingIndicator]
+        self.messageImageView.image = imageAssets?[.ninchatIconChatWritingIndicator]
         self.messageImageView.tintColor = .black
 
         /// Apply asset overrides
@@ -103,7 +103,7 @@ extension ChatTypingCell: LoadingCell {
         self.bubbleImageView.image = imageAssets?[.chatBubbleLeft]
 
         self.messageImageView.backgroundColor = .white
-        self.messageImageView.image = imageAssets?[.chatWritingIndicator]
+        self.messageImageView.image = imageAssets?[.ninchatIconChatWritingIndicator]
         self.messageImageView.tintColor = .black
 
         /// Apply asset overrides

--- a/NinchatSDKSwift/Implementations/View/UIKit/Chat View/ComposeContentView.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Chat View/ComposeContentView.swift
@@ -138,7 +138,7 @@ final class ComposeContentView: UIView, ComposeContentViewProtocol {
         /// Title label
         self.titleLabel = UILabel(frame: .zero)
         self.titleLabel?.font = .ninchat
-        self.titleLabel?.textColor = colorAssets?[.chatBubbleLeftText] ?? .black
+        self.titleLabel?.textColor = colorAssets?[.ninchatColorChatBubbleLeftText] ?? .black
         self.addSubview(self.titleLabel!)
     
         /// Send button

--- a/NinchatSDKSwift/Implementations/View/UIKit/Confirm View/ConfirmCloseChatView.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Confirm View/ConfirmCloseChatView.swift
@@ -44,7 +44,7 @@ final class ConfirmCloseChatView: UIView, ConfirmView {
             self.bottomContainerView.backgroundColor = backgroundColor
         }
         
-        if let textColor = self.delegate?.override(colorAsset: .modalText) {
+        if let textColor = self.delegate?.override(colorAsset: .ninchatColorModalTitleText) {
             self.titleLabel.textColor = textColor
             self.infoTextView.textColor = textColor
         }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Confirm View/ConfirmCloseChatView.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Confirm View/ConfirmCloseChatView.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-final class ConfirmCloseChatView: UIView, ConfirmView {
+final class ConfirmCloseChatView: UIView, HasCustomLayer, ConfirmView {
     
     // MARK: - Outlets
     
@@ -14,17 +14,17 @@ final class ConfirmCloseChatView: UIView, ConfirmView {
     @IBOutlet private(set) weak var bottomContainerView: UIView!
     @IBOutlet private(set) weak var titleLabel: UILabel!
     @IBOutlet private(set) weak var infoTextView: UITextView!
-    @IBOutlet private(set) weak var confirmButton: Button! {
-        didSet {
-            confirmButton.round(borderWidth: 1.0)
-        }
+    @IBOutlet private(set) weak var confirmButton: Button!
+    @IBOutlet private(set) weak var cancelButton: Button!
+
+    // MARK: - UIView
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        applyLayerOverride(view: headerContainerView)
+        applyLayerOverride(view: bottomContainerView)
     }
-    @IBOutlet private(set) weak var cancelButton: Button! {
-        didSet {
-            cancelButton.round(borderWidth: 1.0, borderColor: .defaultBackgroundButton)
-        }
-    }
-    
+
     // MARK: - ConfirmView
     
     var onViewAction: OnViewAction?
@@ -34,16 +34,22 @@ final class ConfirmCloseChatView: UIView, ConfirmView {
             self.overrideAssets()
         }
     }
-        
+
     func overrideAssets() {
         confirmButton.overrideAssets(with: self.delegate, isPrimary: true)
         cancelButton.overrideAssets(with: self.delegate, isPrimary: false)
 
-        if let backgroundColor = self.delegate?.override(colorAsset: .modalBackground) {
+        if let layer = self.delegate?.override(layerAsset: .ninchatModalTop) {
+            self.headerContainerView.layer.insertSublayer(layer, at: 0)
+        }
+        if let layer = self.delegate?.override(layerAsset: .ninchatModalBottom) {
+            self.bottomContainerView.layer.insertSublayer(layer, at: 0)
+        }
+        /// TODO: REMOVE legacy delegate
+        else if let backgroundColor = self.delegate?.override(colorAsset: .modalBackground) {
             self.headerContainerView.backgroundColor = backgroundColor
             self.bottomContainerView.backgroundColor = backgroundColor
         }
-        
         if let textColor = self.delegate?.override(colorAsset: .ninchatColorModalTitleText) {
             self.titleLabel.textColor = textColor
             self.infoTextView.textColor = textColor
@@ -52,12 +58,10 @@ final class ConfirmCloseChatView: UIView, ConfirmView {
         if let dialogTitle = sessionManager?.siteConfiguration.confirmDialogTitle {
             self.infoTextView.setAttributed(text: dialogTitle, font: .ninchat)
         }
-        
         if let confirmText = sessionManager?.translate(key: Constants.kCloseChatText.rawValue, formatParams: [:]) {
             self.titleLabel.text = confirmText
             self.confirmButton.setTitle(confirmText, for: .normal)
         }
-        
         if let cancelText = sessionManager?.translate(key: Constants.kCancelDialog.rawValue, formatParams: [:]) {
             self.cancelButton.setTitle(cancelText, for: .normal)
         }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Confirm View/ConfirmVideoCallView.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Confirm View/ConfirmVideoCallView.swift
@@ -57,7 +57,7 @@ final class ConfirmVideoCallView: UIView, ConfirmVideoCallViewProtocol {
             self.bottomContainerView.backgroundColor = backgroundColor
         }
         
-        if let textColor = self.delegate?.override(colorAsset: .modalText) {
+        if let textColor = self.delegate?.override(colorAsset: .ninchatColorModalTitleText) {
             self.titleLabel.textColor = textColor
             self.usernameLabel.textColor = textColor
             self.infoLabel.textColor = textColor

--- a/NinchatSDKSwift/Implementations/View/UIKit/Faces View/FacesView.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Faces View/FacesView.swift
@@ -48,7 +48,7 @@ final class FacesView: UIView, FacesViewProtocol {
         if let positive = self.delegate?.override(imageAsset: .ninchatIconRatingPositive) {
             self.positiveButton.setImage(positive, for: .normal)
         }
-        if let positiveColor = self.delegate?.override(colorAsset: .ratingPositiveText) {
+        if let positiveColor = self.delegate?.override(colorAsset: .ninchatColorRatingPositiveText) {
             self.positiveLabel.textColor = positiveColor
         }
         
@@ -58,7 +58,7 @@ final class FacesView: UIView, FacesViewProtocol {
         if let neutral = self.delegate?.override(imageAsset: .ninchatIconRatingNeutral) {
             self.neutralButton.setImage(neutral, for: .normal)
         }
-        if let neutralColor = self.delegate?.override(colorAsset: .ratingNeutralText) {
+        if let neutralColor = self.delegate?.override(colorAsset: .ninchatColorRatingNeutralText) {
             self.neutralLabel.textColor = neutralColor
         }
 
@@ -68,7 +68,7 @@ final class FacesView: UIView, FacesViewProtocol {
         if let negative = self.delegate?.override(imageAsset: .ninchatIconRatingNegative) {
             self.negativeButton.setImage(negative, for: .normal)
         }
-        if let negativeColor = self.delegate?.override(colorAsset: .ratingNegativeText) {
+        if let negativeColor = self.delegate?.override(colorAsset: .ninchatColorRatingNegativeText) {
             self.negativeLabel.textColor = negativeColor
         }
     }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Faces View/FacesView.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Faces View/FacesView.swift
@@ -45,7 +45,7 @@ final class FacesView: UIView, FacesViewProtocol {
         if let positiveTitle = self.sessionManager?.translate(key: Constants.kRatingPositiveText.rawValue, formatParams: [:]) {
             self.positiveLabel.text = positiveTitle
         }
-        if let positive = self.delegate?.override(imageAsset: .iconRatingPositive) {
+        if let positive = self.delegate?.override(imageAsset: .ninchatIconRatingPositive) {
             self.positiveButton.setImage(positive, for: .normal)
         }
         if let positiveColor = self.delegate?.override(colorAsset: .ratingPositiveText) {
@@ -55,7 +55,7 @@ final class FacesView: UIView, FacesViewProtocol {
         if let neutralTitle = self.sessionManager?.translate(key: Constants.kRatingNeutralText.rawValue, formatParams: [:]) {
             self.neutralLabel.text = neutralTitle
         }
-        if let neutral = self.delegate?.override(imageAsset: .iconRatingNeutral) {
+        if let neutral = self.delegate?.override(imageAsset: .ninchatIconRatingNeutral) {
             self.neutralButton.setImage(neutral, for: .normal)
         }
         if let neutralColor = self.delegate?.override(colorAsset: .ratingNeutralText) {
@@ -65,7 +65,7 @@ final class FacesView: UIView, FacesViewProtocol {
         if let negativeTitle = self.sessionManager?.translate(key: Constants.kRatingNegativeText.rawValue, formatParams: [:]) {
             self.negativeLabel.text = negativeTitle
         }
-        if let negative = self.delegate?.override(imageAsset: .iconRatingNegative) {
+        if let negative = self.delegate?.override(imageAsset: .ninchatIconRatingNegative) {
             self.negativeButton.setImage(negative, for: .normal)
         }
         if let negativeColor = self.delegate?.override(colorAsset: .ratingNegativeText) {

--- a/NinchatSDKSwift/Implementations/View/UIKit/Input Controls/ChatInputControls.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Input Controls/ChatInputControls.swift
@@ -24,7 +24,7 @@ protocol ChatInputControlsProtocol: UIView, ChatInputActions {
     func overrideAssets()
 }
 
-final class ChatInputControls: UIView, ChatInputControlsProtocol {
+final class ChatInputControls: UIView, HasCustomLayer, ChatInputControlsProtocol {
     
     private var isOnPlaceholderMode: Bool = true {
         didSet {
@@ -77,48 +77,47 @@ final class ChatInputControls: UIView, ChatInputControlsProtocol {
     
     override func layoutSubviews() {
         super.layoutSubviews()
-        UIView.applyLayerOverride(view: self.sendMessageButton)
+        applyLayerOverride(view: sendMessageButton)
     }
     
     func overrideAssets() {
+        self.sendMessageButton.backgroundColor = .clear
+        self.sendMessageButton.setImage(nil, for: .normal)
+        self.sendMessageButton.contentVerticalAlignment = .center
+        self.sendMessageButton.contentHorizontalAlignment = .center
         if let sendButtonTitle = self.sessionManager?.siteConfiguration.sendButtonTitle {
             self.sendMessageButtonWidthConstraint.isActive = false
-            self.sendMessageButton.setImage(nil, for: .normal)
-            self.sendMessageButton.backgroundColor = .clear
             self.sendMessageButton.setTitle(sendButtonTitle, for: .normal)
             self.sendMessageButton.contentEdgeInsets = UIEdgeInsets(top: 0, left: 15, bottom: 0, right: 15)
-            
+        }
+
+        if let layer = delegate?.override(layerAsset: .ninchatTextareaSubmitButton) {
+            sendMessageButton.layer.insertSublayer(layer, below: sendMessageButton.titleLabel?.layer)
+        }
+        /// TODO: REMOVE legacy delegate
+        else if let sendButtonTitle = self.sessionManager?.siteConfiguration.sendButtonTitle {
             if let backgroundColor = self.delegate?.override(colorAsset: .textareaSubmit) {
                 self.sendMessageButton.backgroundColor = backgroundColor
             }
-
             if let backgroundImage = self.delegate?.override(imageAsset: .textareaSubmitButton) {
                 self.sendMessageButton.setBackgroundImage(backgroundImage, for: .normal)
             } else if let backgroundBundle = UIImage(named: "icon_send_message_border", in: .SDKBundle, compatibleWith: nil) {
                 self.sendMessageButton.setBackgroundImage(backgroundBundle, for: .normal)
             }
-            
-            if let titleColor = self.delegate?.override(colorAsset: .ninchatColorTextareaSubmitText) {
-                self.sendMessageButton.setTitleColor(titleColor, for: .normal)
-            }
-            
-            if let layer = self.delegate?.override(layerAsset: .ninchatTextareaSubmitButton) {
-                self.sendMessageButton.layer.addSublayer(layer)
-            }
-            
         } else if let buttonImage = self.delegate?.override(imageAsset: .textareaSubmitButton) {
             self.sendMessageButton.setImage(buttonImage, for: .normal)
         }
-        
+
+        if let titleColor = self.delegate?.override(colorAsset: .ninchatColorTextareaSubmitText) {
+            self.sendMessageButton.setTitleColor(titleColor, for: .normal)
+        }
         if let attachmentIcon = self.delegate?.override(imageAsset: .ninchatIconTextareaAttachment) {
             self.attachmentButton.setImage(attachmentIcon, for: .normal)
         }
-        
         if let inputTextColor = self.delegate?.override(colorAsset: .ninchatColorTextareaText) {
             self.textInput.textColor = inputTextColor
             textColor = inputTextColor
         }
-
         if let placeholderColor = self.delegate?.override(colorAsset: .ninchatColorTextareaPlaceholder) {
             self.placeholderColor = placeholderColor
         }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Input Controls/ChatInputControls.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Input Controls/ChatInputControls.swift
@@ -98,7 +98,7 @@ final class ChatInputControls: UIView, ChatInputControlsProtocol {
                 self.sendMessageButton.setBackgroundImage(backgroundBundle, for: .normal)
             }
             
-            if let titleColor = self.delegate?.override(colorAsset: .textareaSubmitText) {
+            if let titleColor = self.delegate?.override(colorAsset: .ninchatColorTextareaSubmitText) {
                 self.sendMessageButton.setTitleColor(titleColor, for: .normal)
             }
             
@@ -114,12 +114,12 @@ final class ChatInputControls: UIView, ChatInputControlsProtocol {
             self.attachmentButton.setImage(attachmentIcon, for: .normal)
         }
         
-        if let inputTextColor = self.delegate?.override(colorAsset: .textareaText) {
+        if let inputTextColor = self.delegate?.override(colorAsset: .ninchatColorTextareaText) {
             self.textInput.textColor = inputTextColor
             textColor = inputTextColor
         }
 
-        if let placeholderColor = self.delegate?.override(colorAsset: .textareaPlaceholder) {
+        if let placeholderColor = self.delegate?.override(colorAsset: .ninchatColorTextareaPlaceholder) {
             self.placeholderColor = placeholderColor
         }
         self.updatePlaceholder()

--- a/NinchatSDKSwift/Implementations/View/UIKit/Input Controls/ChatInputControls.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Input Controls/ChatInputControls.swift
@@ -110,7 +110,7 @@ final class ChatInputControls: UIView, ChatInputControlsProtocol {
             self.sendMessageButton.setImage(buttonImage, for: .normal)
         }
         
-        if let attachmentIcon = self.delegate?.override(imageAsset: .iconTextareaAttachment) {
+        if let attachmentIcon = self.delegate?.override(imageAsset: .ninchatIconTextareaAttachment) {
             self.attachmentButton.setImage(attachmentIcon, for: .normal)
         }
         

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Cells/QuestionnaireNavigationCell.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Cells/QuestionnaireNavigationCell.swift
@@ -7,7 +7,7 @@
 import UIKit
 import AnyCodable
 
-final class QuestionnaireNavigationCell: UITableViewCell, QuestionnaireNavigationButtons {
+final class QuestionnaireNavigationCell: UITableViewCell, HasCustomLayer, QuestionnaireNavigationButtons {
 
     // MARK: - QuestionnaireElementWithNavigationButtons
 
@@ -36,6 +36,17 @@ final class QuestionnaireNavigationCell: UITableViewCell, QuestionnaireNavigatio
         UIView(frame: .zero)
     }()
 
+    override func layoutSublayers(of layer: CALayer) {
+        super.layoutSublayers(of: layer)
+
+        if let nextButton = self.buttons.arrangedSubviews.compactMap({ $0 as? Button }).first(where: { $0.type == .next }) {
+            applyLayerOverride(view: nextButton)
+        }
+        if let backButton = self.buttons.arrangedSubviews.compactMap({ $0 as? Button }).first(where: { $0.type == .back }) {
+            applyLayerOverride(view: backButton)
+        }
+    }
+
     func overrideAssets(with delegate: NINChatSessionInternalDelegate?) {
         if let nextButton = self.buttons.arrangedSubviews.compactMap({ $0 as? Button }).first(where: { $0.type == .next }) {
             if nextButton.titleLabel?.text?.isEmpty ?? true {
@@ -44,8 +55,16 @@ final class QuestionnaireNavigationCell: UITableViewCell, QuestionnaireNavigatio
                 nextButton.setTitleColor(delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorNavigationNextText) ?? .white, for: .normal)
                 nextButton.setTitleColor(delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorNavigationNextText) ?? .white, for: .selected)
             }
-            nextButton.layer.borderColor = delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorNavigationNextText)?.cgColor ?? UIColor.QBlueButtonNormal.cgColor
-            nextButton.backgroundColor = delegate?.override(questionnaireAsset: .navigationNextBackground) ?? .QBlueButtonNormal
+
+            if let layer = delegate?.override(layerAsset: .ninchatQuestionnaireNavigationNext) {
+                nextButton.layer.insertSublayer(layer, at: 0)
+            }
+            /// TODO: REMOVE legacy delegate
+            else {
+                nextButton.layer.borderColor = delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorNavigationNextText)?.cgColor ?? UIColor.QBlueButtonNormal.cgColor
+                nextButton.backgroundColor = delegate?.override(questionnaireAsset: .navigationNextBackground) ?? .QBlueButtonNormal
+                nextButton.round(radius: 45.0 / 2, borderWidth: 1.0, borderColor: .QBlueButtonNormal)
+            }
         }
         if let backButton = self.buttons.arrangedSubviews.compactMap({ $0 as? Button }).first(where: { $0.type == .back }) {
             if backButton.titleLabel?.text?.isEmpty ?? true {
@@ -54,8 +73,16 @@ final class QuestionnaireNavigationCell: UITableViewCell, QuestionnaireNavigatio
                 backButton.setTitleColor(delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorNavigationBackText) ?? .QBlueButtonNormal, for: .normal)
                 backButton.setTitleColor(delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorNavigationBackText) ?? .QBlueButtonNormal, for: .selected)
             }
-            backButton.layer.borderColor = delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorNavigationBackText)?.cgColor ?? UIColor.QBlueButtonNormal.cgColor
-            backButton.backgroundColor = delegate?.override(questionnaireAsset: .navigationBackBackground) ?? .white
+
+            if let layer = delegate?.override(layerAsset: .ninchatQuestionnaireNavigationBack) {
+                backButton.layer.insertSublayer(layer, at: 0)
+            }
+            /// TODO: REMOVE legacy delegate
+            else {
+                backButton.layer.borderColor = delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorNavigationBackText)?.cgColor ?? UIColor.QBlueButtonNormal.cgColor
+                backButton.backgroundColor = delegate?.override(questionnaireAsset: .navigationBackBackground) ?? .white
+                backButton.round(radius: 45.0 / 2, borderWidth: 1.0, borderColor: .QBlueButtonNormal)
+            }
         }
     }
 
@@ -168,7 +195,6 @@ extension QuestionnaireNavigationCell {
         button.titleLabel?.lineBreakMode = .byTruncatingTail
         button
             .fix(width: button.intrinsicContentSize.width + 32.0, height: 45.0)
-            .round(radius: 45.0 / 2, borderWidth: 1.0, borderColor: .QBlueButtonNormal)
             .width?.priority = .almostRequired
     }
 

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Cells/QuestionnaireNavigationCell.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Cells/QuestionnaireNavigationCell.swift
@@ -39,22 +39,22 @@ final class QuestionnaireNavigationCell: UITableViewCell, QuestionnaireNavigatio
     func overrideAssets(with delegate: NINChatSessionInternalDelegate?) {
         if let nextButton = self.buttons.arrangedSubviews.compactMap({ $0 as? Button }).first(where: { $0.type == .next }) {
             if nextButton.titleLabel?.text?.isEmpty ?? true {
-                nextButton.imageView?.tint = delegate?.override(questionnaireAsset: .navigationNextText) ?? .white
+                nextButton.imageView?.tint = delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorNavigationNextText) ?? .white
             } else {
-                nextButton.setTitleColor(delegate?.override(questionnaireAsset: .navigationNextText) ?? .white, for: .normal)
-                nextButton.setTitleColor(delegate?.override(questionnaireAsset: .navigationNextText) ?? .white, for: .selected)
+                nextButton.setTitleColor(delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorNavigationNextText) ?? .white, for: .normal)
+                nextButton.setTitleColor(delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorNavigationNextText) ?? .white, for: .selected)
             }
-            nextButton.layer.borderColor = delegate?.override(questionnaireAsset: .navigationNextText)?.cgColor ?? UIColor.QBlueButtonNormal.cgColor
+            nextButton.layer.borderColor = delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorNavigationNextText)?.cgColor ?? UIColor.QBlueButtonNormal.cgColor
             nextButton.backgroundColor = delegate?.override(questionnaireAsset: .navigationNextBackground) ?? .QBlueButtonNormal
         }
         if let backButton = self.buttons.arrangedSubviews.compactMap({ $0 as? Button }).first(where: { $0.type == .back }) {
             if backButton.titleLabel?.text?.isEmpty ?? true {
-                backButton.imageView?.tint = delegate?.override(questionnaireAsset: .navigationBackText) ?? .QBlueButtonNormal
+                backButton.imageView?.tint = delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorNavigationBackText) ?? .QBlueButtonNormal
             } else {
-                backButton.setTitleColor(delegate?.override(questionnaireAsset: .navigationBackText) ?? .QBlueButtonNormal, for: .normal)
-                backButton.setTitleColor(delegate?.override(questionnaireAsset: .navigationBackText) ?? .QBlueButtonNormal, for: .selected)
+                backButton.setTitleColor(delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorNavigationBackText) ?? .QBlueButtonNormal, for: .normal)
+                backButton.setTitleColor(delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorNavigationBackText) ?? .QBlueButtonNormal, for: .selected)
             }
-            backButton.layer.borderColor = delegate?.override(questionnaireAsset: .navigationBackText)?.cgColor ?? UIColor.QBlueButtonNormal.cgColor
+            backButton.layer.borderColor = delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorNavigationBackText)?.cgColor ?? UIColor.QBlueButtonNormal.cgColor
             backButton.backgroundColor = delegate?.override(questionnaireAsset: .navigationBackBackground) ?? .white
         }
     }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementCheckbox.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementCheckbox.swift
@@ -152,8 +152,8 @@ final class QuestionnaireElementCheckbox: UIView, QuestionnaireElement, Question
 extension Button {
     fileprivate func overrideQuestionnaireAsset(with delegate: NINChatSessionInternalDelegate?, isPrimary: Bool) {
         self.titleLabel?.font = .ninchat
-        self.setTitleColor(delegate?.override(questionnaireAsset: .checkboxSecondaryText) ?? UIColor.QGrayButton, for: .normal)
-        self.setTitleColor(delegate?.override(questionnaireAsset: .checkboxPrimaryText) ?? UIColor.QBlueButtonNormal, for: .selected)
+        self.setTitleColor(delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorCheckboxUnselectedText) ?? UIColor.QGrayButton, for: .normal)
+        self.setTitleColor(delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorCheckboxSelectedText) ?? UIColor.QBlueButtonNormal, for: .selected)
     }
 }
 

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementRadio.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementRadio.swift
@@ -124,10 +124,10 @@ extension Button {
         self.titleLabel?.font = .ninchat
 
         self.setBackgroundImage((delegate?.override(questionnaireAsset: .radioSecondaryBackground) ?? .white).toImage, for: .normal)
-        self.setTitleColor(delegate?.override(questionnaireAsset: .radioSecondaryText) ?? .QGrayButton, for: .normal)
+        self.setTitleColor(delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorRadioUnselectedText) ?? .QGrayButton, for: .normal)
 
         self.setBackgroundImage((delegate?.override(questionnaireAsset: .radioPrimaryBackground) ?? .white).toImage, for: .selected)
-        self.setTitleColor(delegate?.override(questionnaireAsset: .radioPrimaryText) ?? .QBlueButtonNormal, for: .selected)
+        self.setTitleColor(delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorRadioSelectedText) ?? .QBlueButtonNormal, for: .selected)
 
         self.roundButton()
     }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementRadio.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementRadio.swift
@@ -10,7 +10,7 @@ protocol QuestionnaireExitElement {
     var isExitElement: Bool { set get }
 }
 
-class QuestionnaireElementRadio: UIView, QuestionnaireElementWithTitle, QuestionnaireSettable, QuestionnaireOptionSelectableElement, QuestionnaireExitElement {
+class QuestionnaireElementRadio: UIView, HasCustomLayer, QuestionnaireElementWithTitle, QuestionnaireSettable, QuestionnaireOptionSelectableElement, QuestionnaireExitElement {
 
     // MARK: - QuestionnaireElement
 
@@ -37,6 +37,7 @@ class QuestionnaireElementRadio: UIView, QuestionnaireElementWithTitle, Question
     var elementHeight: CGFloat = 0
 
     func overrideAssets(with delegate: NINChatSessionInternalDelegate?) {
+        self.delegate = delegate
         self.overrideTitle(delegate: delegate)
         self.view.subviews.compactMap({ $0 as? Button }).forEach({ $0.overrideQuestionnaireAsset(with: delegate, isPrimary: $0.isSelected) })
     }
@@ -73,6 +74,7 @@ class QuestionnaireElementRadio: UIView, QuestionnaireElementWithTitle, Question
 
     // MARK: - Subviews - QuestionnaireElementWithTitleAndOptions + QuestionnaireElementHasButtons
 
+    private var delegate: NINChatSessionInternalDelegate?
     private(set) lazy var title: UILabel = {
         UILabel(frame: .zero)
     }()
@@ -99,6 +101,7 @@ class QuestionnaireElementRadio: UIView, QuestionnaireElementWithTitle, Question
 
     override func layoutSubviews() {
         super.layoutSubviews()
+        applyLayerOverride(view: self)
 
         self.decorateView()
         self.layoutIfNeeded()
@@ -123,13 +126,37 @@ extension Button {
     fileprivate func overrideQuestionnaireAsset(with delegate: NINChatSessionInternalDelegate?, isPrimary: Bool) {
         self.titleLabel?.font = .ninchat
 
-        self.setBackgroundImage((delegate?.override(questionnaireAsset: .radioSecondaryBackground) ?? .white).toImage, for: .normal)
+        switch isPrimary {
+        case false:
+            if let layer = delegate?.override(layerAsset: .ninchatQuestionnaireRadioUnselected) {
+                if let old = self.layer.sublayers?.first(where: { $0.name == LAYER_NAME }) {
+                    self.layer.replaceSublayer(old, with: layer)
+                } else {
+                    self.layer.insertSublayer(layer, at: 0)
+                }
+            }
+            /// TODO: REMOVE legacy delegate
+            else {
+                self.setBackgroundImage((delegate?.override(questionnaireAsset: .radioSecondaryBackground) ?? .white).toImage, for: .normal)
+                self.roundButton()
+            }
+        case true:
+            if let layer = delegate?.override(layerAsset: .ninchatQuestionnaireRadioSelected) {
+                if let old = self.layer.sublayers?.first(where: { $0.name == LAYER_NAME }) {
+                    self.layer.replaceSublayer(old, with: layer)
+                } else {
+                    self.layer.insertSublayer(layer, at: 0)
+                }
+            }
+                /// TODO: REMOVE legacy delegate
+            else {
+                self.setBackgroundImage((delegate?.override(questionnaireAsset: .radioPrimaryBackground) ?? .white).toImage, for: .selected)
+                self.roundButton()
+            }
+        }
+
         self.setTitleColor(delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorRadioUnselectedText) ?? .QGrayButton, for: .normal)
-
-        self.setBackgroundImage((delegate?.override(questionnaireAsset: .radioPrimaryBackground) ?? .white).toImage, for: .selected)
         self.setTitleColor(delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorRadioSelectedText) ?? .QBlueButtonNormal, for: .selected)
-
-        self.roundButton()
     }
 }
 
@@ -177,7 +204,6 @@ extension QuestionnaireElementRadio {
             .fix(top: (8.0, upperView ?? self.view), isRelative: (upperView != nil))
             .fix(height: max(45.0, button.intrinsicContentSize.height + 16.0))
             .center(toX: self.view)
-            .roundButton()
 
         if self.view.height == nil {
             self.view.fix(height: 0)
@@ -186,12 +212,13 @@ extension QuestionnaireElementRadio {
     }
 
     private func applySelection(to button: UIButton) {
-        self.view.subviews.compactMap({ $0 as? Button }).forEach { button in
-            button.isSelected = false
-            (button as Button).roundButton()
-        }
+        self.view.subviews.compactMap({ $0 as? Button }).forEach({
+            $0.isSelected = false
+            $0.overrideQuestionnaireAsset(with: self.delegate, isPrimary: $0.isSelected)
+        })
+
         button.isSelected = true
-        (button as? Button)?.roundButton()
+        (button as! Button).overrideQuestionnaireAsset(with: self.delegate, isPrimary: button.isSelected)
     }
 }
 

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementSelect.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementSelect.swift
@@ -41,12 +41,12 @@ final class QuestionnaireElementSelect: UIView, QuestionnaireElementWithTitle, Q
 
         normalBackgroundColor = delegate?.override(questionnaireAsset: .selectDeselectedBackground) ?? .white
         selectedBackgroundColor = delegate?.override(questionnaireAsset: .selectSelectedBackground) ?? .white
-        selectedOption.textColor = delegate?.override(questionnaireAsset: .selectNormalText) ?? .QGrayButton
+        selectedOption.textColor = delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorSelectUnselectText) ?? .QGrayButton
 
         /// On scrolling the table, the `selectedOption` highlight status changes back to 'false'
         /// We should reset it to avoid breaking the UI
         selectedOption.isHighlighted = (selectionIndicator.tint != selectedOption.textColor) && (self.isCompleted ?? false)
-        selectedOption.highlightedTextColor = delegate?.override(questionnaireAsset: .selectSelectedText) ?? .QBlueButtonNormal
+        selectedOption.highlightedTextColor = delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorSelectSelectedText) ?? .QBlueButtonNormal
     }
 
     // MARK: - QuestionnaireSettable

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementText.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementText.swift
@@ -52,7 +52,7 @@ final class QuestionnaireElementText: UITextView, QuestionnaireElement {
         if let overriddenColor = delegate?.override(questionnaireAsset: .titleTextColor) {
             self.setAttributed(text: self.elementConfiguration?.label ?? "", font: .ninchat, color: overriddenColor, width:  self.estimatedWidth())
         }
-        if let linkColor = delegate?.override(colorAsset: .link) {
+        if let linkColor = delegate?.override(colorAsset: .ninchatColorLink) {
             self.linkTextAttributes = [NSAttributedString.Key.foregroundColor: linkColor]
         }
     }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementText.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementText.swift
@@ -49,7 +49,7 @@ final class QuestionnaireElementText: UITextView, QuestionnaireElement {
     var elementHeight: CGFloat = 0
 
     func overrideAssets(with delegate: NINChatSessionInternalDelegate?) {
-        if let overriddenColor = delegate?.override(questionnaireAsset: .titleTextColor) {
+        if let overriddenColor = delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorTitleText) {
             self.setAttributed(text: self.elementConfiguration?.label ?? "", font: .ninchat, color: overriddenColor, width:  self.estimatedWidth())
         }
         if let linkColor = delegate?.override(colorAsset: .ninchatColorLink) {

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextArea.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextArea.swift
@@ -35,7 +35,7 @@ final class QuestionnaireElementTextArea: UIView, QuestionnaireElementWithTitle,
 
     func overrideAssets(with delegate: NINChatSessionInternalDelegate?) {
         self.overrideTitle(delegate: delegate)
-        self.view.textColor = delegate?.override(questionnaireAsset: .textInputColor) ?? .black
+        self.view.textColor = delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorTextInput) ?? .black
     }
 
     // MARK: - QuestionnaireSettable

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextField.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextField.swift
@@ -35,7 +35,7 @@ final class QuestionnaireElementTextField: UIView, QuestionnaireElementWithTitle
 
     func overrideAssets(with delegate: NINChatSessionInternalDelegate?) {
         self.overrideTitle(delegate: delegate)
-        self.view.textColor = delegate?.override(questionnaireAsset: .textInputColor) ?? .black
+        self.view.textColor = delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorTextInput) ?? .black
     }
 
     // MARK: - QuestionnaireSettable

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/QuestionnaireElement.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/QuestionnaireElement.swift
@@ -76,7 +76,7 @@ extension QuestionnaireElementWithTitle {
         guard let titleComponents = self.title.text?.components(separatedBy: self.requiredIndicator) else { return }
 
         let attributedString = NSMutableAttributedString(string: self.title.text!)
-        let defaultColor = delegate?.override(questionnaireAsset: .titleTextColor) ?? UIColor.black
+        let defaultColor = delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorTitleText) ?? UIColor.black
         if let restComponent = titleComponents.filter({ !$0.isEmpty }).first, restComponent != self.requiredIndicator {
             attributedString.applyUpdates(to: restComponent, color: defaultColor)
         }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Top Bar/TopBar.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Top Bar/TopBar.swift
@@ -51,7 +51,7 @@ final class TopBar: UIView, TopBarProtocol {
     @IBOutlet private(set) weak var closeButton: UIImageView!
     
     func overrideAssets() {
-        if let downloadButton = self.delegate?.override(imageAsset: .iconDownload) {
+        if let downloadButton = self.delegate?.override(imageAsset: .ninchatIconDownload) {
             self.downloadButton.image = downloadButton
         }
         if let closeButton = self.delegate?.override(imageAsset: .iconChatCloseButton) {

--- a/NinchatSDKSwift/Implementations/View/UIKit/Video View/VideoView.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Video View/VideoView.swift
@@ -109,23 +109,23 @@ final class VideoView: UIView, VideoViewProtocol {
     }
     
     func overrideAssets() {
-        if let hangupIcon = self.delegate?.override(imageAsset: .iconVideoHangup) {
+        if let hangupIcon = self.delegate?.override(imageAsset: .ninchatIconVideoHangup) {
             self.hangupButton.setImage(hangupIcon, for: .normal)
         }
         
-        if let micOnIcon = self.delegate?.override(imageAsset: .iconVideoMicrophoneOn) {
+        if let micOnIcon = self.delegate?.override(imageAsset: .ninchatIconVideoMicrophoneOn) {
             self.microphoneEnabledButton.setImage(micOnIcon, for: .normal)
         }
         
-        if let micOffIcon = self.delegate?.override(imageAsset: .iconVideoMicrophoneOff) {
+        if let micOffIcon = self.delegate?.override(imageAsset: .ninchatIconVideoMicrophoneOff) {
             self.microphoneEnabledButton.setImage(micOffIcon, for: .selected)
         }
         
-        if let cameraOnIcon = self.delegate?.override(imageAsset: .iconVideoCameraOn) {
+        if let cameraOnIcon = self.delegate?.override(imageAsset: .ninchatIconVideoCameraOn) {
             self.cameraEnabledButton.setImage(cameraOnIcon, for: .normal)
         }
         
-        if let cameraOffIcon = self.delegate?.override(imageAsset: .iconVideoCameraOff) {
+        if let cameraOffIcon = self.delegate?.override(imageAsset: .ninchatIconVideoCameraOff) {
             self.cameraEnabledButton.setImage(cameraOffIcon, for: .selected)
         }
     }

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINChatViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINChatViewController.swift
@@ -385,7 +385,7 @@ extension NINChatViewController {
         videoView.overrideAssets()
         inputControlsView.overrideAssets()
         
-        if let backgroundImage = self.delegate?.override(imageAsset: .chatBackground) {
+        if let backgroundImage = self.delegate?.override(imageAsset: .ninchatChatBackground) {
             self.backgroundView.backgroundColor = UIColor(patternImage: backgroundImage)
         } else if let bundleImage = UIImage(named: "chat_background_pattern", in: .SDKBundle, compatibleWith: nil) {
             self.backgroundView.backgroundColor = UIColor(patternImage: bundleImage)

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINInitialViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINInitialViewController.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-final class NINInitialViewController: UIViewController, ViewController {
+final class NINInitialViewController: UIViewController, HasCustomLayer, ViewController {
     
     // MARK: - Injected
     
@@ -35,7 +35,6 @@ final class NINInitialViewController: UIViewController, ViewController {
             if let closeText = self.sessionManager?.translate(key: Constants.kCloseWindowText.rawValue, formatParams: [:]) {
                 closeWindowButton.setTitle(closeText, for: .normal)
             }
-            closeWindowButton.round(borderWidth: 1.0, borderColor: .defaultBackgroundButton)
         }
     }
     @IBOutlet private(set) var motdTextView: UITextView! {
@@ -76,6 +75,13 @@ final class NINInitialViewController: UIViewController, ViewController {
         self.overrideAssets()
     }
 
+    override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+
+        applyLayerOverride(view: self.topContainerView)
+        applyLayerOverride(view: self.bottomContainerView)
+    }
+
     // MARK: - User actions
     
     @IBAction private func closeWindowButtonPressed(button: UIButton) {
@@ -88,9 +94,18 @@ final class NINInitialViewController: UIViewController, ViewController {
 private extension NINInitialViewController {
     private func overrideAssets() {
         closeWindowButton?.overrideAssets(with: delegate, isPrimary: false)
-        if let topBackgroundColor = delegate?.override(colorAsset: .backgroundTop) {
+
+        if let layer = delegate?.override(layerAsset: .ninchatBackgroundTop) {
+            topContainerView.layer.insertSublayer(layer, at: 0)
+        }
+        /// TODO: REMOVE legacy delegate
+        else if let topBackgroundColor = delegate?.override(colorAsset: .backgroundTop) {
             topContainerView.backgroundColor = topBackgroundColor
         }
+        if let layer = delegate?.override(layerAsset: .ninchatBackgroundBottom) {
+            bottomContainerView.layer.insertSublayer(layer, at: 0)
+        }
+        /// TODO: REMOVE legacy delegate
         if let bottomBackgroundColor = delegate?.override(colorAsset: .backgroundBottom) {
             bottomContainerView.backgroundColor = bottomBackgroundColor
         }

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINInitialViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINInitialViewController.swift
@@ -60,7 +60,7 @@ final class NINInitialViewController: UIViewController, HasCustomLayer, ViewCont
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         if self.sessionManager?.audienceQueues.filter({ !$0.isClosed }).count ?? 0 > 0 {
             /// There is at least one open queue to join
             self.drawQueueButtons()
@@ -68,11 +68,11 @@ final class NINInitialViewController: UIViewController, HasCustomLayer, ViewCont
             /// Show no queue text
             self.drawNoQueueText()
         }
+        self.overrideAssets()
     }
     
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        self.overrideAssets()
     }
 
     override func viewWillLayoutSubviews() {

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINInitialViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINInitialViewController.swift
@@ -94,13 +94,13 @@ private extension NINInitialViewController {
         if let bottomBackgroundColor = delegate?.override(colorAsset: .backgroundBottom) {
             bottomContainerView.backgroundColor = bottomBackgroundColor
         }
-        if let textTopColor = delegate?.override(colorAsset: .textTop) {
+        if let textTopColor = delegate?.override(colorAsset: .ninchatColorTextTop) {
             welcomeTextView.textColor = textTopColor
         }
-        if let textBottomColor = delegate?.override(colorAsset: .textBottom) {
+        if let textBottomColor = delegate?.override(colorAsset: .ninchatColorTextBottom) {
             motdTextView.textColor = textBottomColor
         }
-        if let linkColor = delegate?.override(colorAsset: .link) {
+        if let linkColor = delegate?.override(colorAsset: .ninchatColorLink) {
             let attribute = [NSAttributedString.Key.foregroundColor: linkColor]
             welcomeTextView.linkTextAttributes = attribute
             motdTextView.linkTextAttributes = attribute

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINInitialViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINInitialViewController.swift
@@ -70,10 +70,6 @@ final class NINInitialViewController: UIViewController, HasCustomLayer, ViewCont
         }
         self.overrideAssets()
     }
-    
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-    }
 
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINQuestionnaireViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINQuestionnaireViewController.swift
@@ -174,7 +174,7 @@ final class NINQuestionnaireViewController: UIViewController, ViewController, Ke
     }
 
     private func overrideAssets() {
-        if let backgroundImage = self.delegate?.override(imageAsset: .questionnaireBackground) {
+        if let backgroundImage = self.delegate?.override(imageAsset: .ninchatQuestionnaireBackground) {
             self.view.backgroundColor = UIColor(patternImage: backgroundImage)
         } else if let bundleImage = UIImage(named: "chat_background_pattern", in: .SDKBundle, compatibleWith: nil) {
             self.view.backgroundColor = UIColor(patternImage: bundleImage)

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINQueueViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINQueueViewController.swift
@@ -28,7 +28,7 @@ final class NINQueueViewController: UIViewController, ViewController {
     @IBOutlet private(set) weak var spinnerImageView: UIImageView!
     @IBOutlet private(set) weak var queueInfoTextView: UITextView! {
         didSet {
-            if let textTopColor = self.delegate?.override(colorAsset: .textTop) {
+            if let textTopColor = self.delegate?.override(colorAsset: .ninchatColorTextTop) {
                 self.queueInfoTextView.textColor = textTopColor
             }
             queueInfoTextView.text = nil
@@ -158,13 +158,13 @@ extension NINQueueViewController {
         if let bottomBackgroundColor = self.delegate?.override(colorAsset: .backgroundBottom) {
             bottomContainerView.backgroundColor = bottomBackgroundColor
         }
-        if let textTopColor = self.delegate?.override(colorAsset: .textTop) {
+        if let textTopColor = self.delegate?.override(colorAsset: .ninchatColorTextTop) {
             queueInfoTextView.textColor = textTopColor
         }
-        if let textBottomColor = self.delegate?.override(colorAsset: .textBottom) {
+        if let textBottomColor = self.delegate?.override(colorAsset: .ninchatColorTextBottom) {
             motdTextView.textColor = textBottomColor
         }
-        if let linkColor = self.delegate?.override(colorAsset: .link) {
+        if let linkColor = self.delegate?.override(colorAsset: .ninchatColorLink) {
             let attribute = [NSAttributedString.Key.foregroundColor: linkColor]
             queueInfoTextView.linkTextAttributes = attribute
             motdTextView.linkTextAttributes = attribute

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINQueueViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINQueueViewController.swift
@@ -149,7 +149,7 @@ extension NINQueueViewController {
     private func overrideAssets() {
         
         closeChatButton.overrideAssets(with: self.delegate)
-        if let spinnerImage = self.delegate?.override(imageAsset: .iconLoader) {
+        if let spinnerImage = self.delegate?.override(imageAsset: .ninchatIconLoader) {
             self.spinnerImageView.image = spinnerImage
         }
         if let topBackgroundColor = self.delegate?.override(colorAsset: .backgroundTop) {

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINRatingViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINRatingViewController.swift
@@ -7,7 +7,7 @@
 import UIKit
 import AutoLayoutSwift
 
-final class NINRatingViewController: UIViewController, ViewController {
+final class NINRatingViewController: UIViewController, HasCustomLayer, ViewController {
     
     // MARK: - Injected
     
@@ -84,7 +84,14 @@ final class NINRatingViewController: UIViewController, ViewController {
         self.overrideAssets()
         self.navigationItem.setHidesBackButton(true, animated: false)
     }
-    
+
+    override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+
+        applyLayerOverride(view: topViewContainer)
+        applyLayerOverride(view: view)
+    }
+
     // MARK: - Setup View
     
     func overrideAssets() {
@@ -101,13 +108,23 @@ final class NINRatingViewController: UIViewController, ViewController {
             }
             
         }
-        
-        if let topBackgroundColor = self.delegate?.override(colorAsset: .backgroundTop) {
+
+        if let layer = delegate?.override(layerAsset: .ninchatBackgroundTop) {
+            topViewContainer.layer.insertSublayer(layer, at: 0)
+        }
+        /// TODO: REMOVE legacy delegate
+        else if let topBackgroundColor = self.delegate?.override(colorAsset: .backgroundTop) {
             self.topViewContainer.backgroundColor = topBackgroundColor
         }
-        if let bottomBackgroundColor = self.delegate?.override(colorAsset: .backgroundBottom) {
+
+        if let layer = delegate?.override(layerAsset: .ninchatBackgroundBottom) {
+            view.layer.insertSublayer(layer, at: 0)
+        }
+        /// TODO: REMOVE legacy delegate
+        else if let bottomBackgroundColor = self.delegate?.override(colorAsset: .backgroundBottom) {
             self.view.backgroundColor = bottomBackgroundColor
         }
+
         if let bubbleColor = self.delegate?.override(colorAsset: .ninchatColorChatBubbleLeftTint) {
             self.titleConversationBubble.tintColor = bubbleColor
         }
@@ -115,7 +132,6 @@ final class NINRatingViewController: UIViewController, ViewController {
             self.titleFormTextView.textColor = textTopColor
             titleConversationTextView.textColor = textTopColor
         }
-        
         if let linkColor = self.delegate?.override(colorAsset: .ninchatColorLink) {
             self.titleFormTextView.linkTextAttributes = [NSAttributedString.Key.foregroundColor: linkColor]
             titleConversationTextView.linkTextAttributes = [NSAttributedString.Key.foregroundColor: linkColor]

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINRatingViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINRatingViewController.swift
@@ -108,15 +108,15 @@ final class NINRatingViewController: UIViewController, ViewController {
         if let bottomBackgroundColor = self.delegate?.override(colorAsset: .backgroundBottom) {
             self.view.backgroundColor = bottomBackgroundColor
         }
-        if let bubbleColor = self.delegate?.override(colorAsset: .chatBubbleLeftTint) {
+        if let bubbleColor = self.delegate?.override(colorAsset: .ninchatColorChatBubbleLeftTint) {
             self.titleConversationBubble.tintColor = bubbleColor
         }
-        if let textTopColor = self.delegate?.override(colorAsset: .textTop) {
+        if let textTopColor = self.delegate?.override(colorAsset: .ninchatColorTextTop) {
             self.titleFormTextView.textColor = textTopColor
             titleConversationTextView.textColor = textTopColor
         }
         
-        if let linkColor = self.delegate?.override(colorAsset: .link) {
+        if let linkColor = self.delegate?.override(colorAsset: .ninchatColorLink) {
             self.titleFormTextView.linkTextAttributes = [NSAttributedString.Key.foregroundColor: linkColor]
             titleConversationTextView.linkTextAttributes = [NSAttributedString.Key.foregroundColor: linkColor]
             self.skipButton.setTitleColor(linkColor, for: .normal)


### PR DESCRIPTION
fixes somia/mobile#313

**Update**
The PR will deprecate old keys and styles (no breaking changes). **However, it will make the following keys unavailable (breaking changes) that were used to replace chat bubble images**
* `.chatBubbleLeft`
* `.chatBubbleLeftRepeated`
* `.chatBubbleRight`
* `.chatBubbleRightRepeated`