### PR TITLE
memory/remove retain cycles

### DIFF
--- a/NinchatSDKSwift/Implementations/Data Source - Delegate/NINPickerControllerDelegate.swift
+++ b/NinchatSDKSwift/Implementations/Data Source - Delegate/NINPickerControllerDelegate.swift
@@ -37,7 +37,7 @@ final class NINPickerControllerDelegateImpl: NSObject, NINPickerControllerDelega
     
     // MARK: - NINPickerControllerDelegate
     
-    private let viewModel: NINChatViewModel
+    private unowned var viewModel: NINChatViewModel!
     
     init(viewModel: NINChatViewModel) {
         self.viewModel = viewModel
@@ -78,7 +78,9 @@ extension NINPickerControllerDelegateImpl {
             }
         }
         
-        DispatchQueue.global(qos: .background).async {
+        DispatchQueue.global(qos: .background).async { [weak self] in
+            guard let `self` = self else { return }
+            
             switch info[UIImagePickerController.InfoKey.mediaType] as! CFString {
             case kUTTypeImage:
                 if fileName.components(separatedBy: ".").count == 1 {
@@ -86,7 +88,9 @@ extension NINPickerControllerDelegateImpl {
                     fileName += ".jpg"
                 }
 
-                if let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage, let data = image.jpegData(compressionQuality: 0.5) {
+                if let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage,
+                   let data = image.jpegData(compressionQuality: 0.5) {
+                    
                     self.viewModel.send(attachment: fileName, data: data) { [weak self] error in
                         self?.onMediaSent?(error)
                     }
@@ -97,7 +101,9 @@ extension NINPickerControllerDelegateImpl {
                     fileName += ".mp4"
                 }
 
-                if let videoURL = info[UIImagePickerController.InfoKey.mediaURL] as? URL, let data = try? Data(contentsOf: videoURL) {
+                if let videoURL = info[UIImagePickerController.InfoKey.mediaURL] as? URL,
+                   let data = try? Data(contentsOf: videoURL) {
+                    
                     self.viewModel.send(attachment: fileName, data: data) { [weak self] error in
                         self?.onMediaSent?(error)
                     }

--- a/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/NINQuestionnaireConversationDataSourceDelegate.swift
+++ b/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/NINQuestionnaireConversationDataSourceDelegate.swift
@@ -22,7 +22,7 @@ final class NINQuestionnaireConversationDataSourceDelegate: QuestionnaireDataSou
 
     // MARK: - NINQuestionnaireFormDelegate
 
-    private var delegate: InternalDelegate?
+    private weak var delegate: NINChatSessionInternalDelegate?
 
     var viewModel: NINQuestionnaireViewModel!
     weak var sessionManager: NINChatSessionManager?
@@ -38,7 +38,7 @@ final class NINQuestionnaireConversationDataSourceDelegate: QuestionnaireDataSou
         }
     }
 
-    init(viewModel: NINQuestionnaireViewModel, sessionManager: NINChatSessionManager, delegate: InternalDelegate?) {
+    init(viewModel: NINQuestionnaireViewModel, sessionManager: NINChatSessionManager, delegate: NINChatSessionInternalDelegate?) {
         self.delegate = delegate
         self.sessionManager = sessionManager
         self.viewModel = viewModel

--- a/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/NINQuestionnaireFormDataSourceDelegate.swift
+++ b/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/NINQuestionnaireFormDataSourceDelegate.swift
@@ -10,7 +10,7 @@ final class NINQuestionnaireFormDataSourceDelegate: QuestionnaireDataSourceDeleg
 
     // MARK: - NINQuestionnaireFormDelegate
 
-    private var delegate: InternalDelegate?
+    private weak var delegate: NINChatSessionInternalDelegate?
 
     var viewModel: NINQuestionnaireViewModel!
     weak var sessionManager: NINChatSessionManager?
@@ -21,7 +21,7 @@ final class NINQuestionnaireFormDataSourceDelegate: QuestionnaireDataSourceDeleg
 
     var isLoadingNewElements: Bool! = false
 
-    init(viewModel: NINQuestionnaireViewModel, sessionManager: NINChatSessionManager, delegate: InternalDelegate?) {
+    init(viewModel: NINQuestionnaireViewModel, sessionManager: NINChatSessionManager, delegate: NINChatSessionInternalDelegate?) {
         self.delegate = delegate
         self.sessionManager = sessionManager
         self.viewModel = viewModel

--- a/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/QuestionnaireDataSourceDelegate.swift
+++ b/NinchatSDKSwift/Implementations/Data Source - Delegate/Questionnaire/QuestionnaireDataSourceDelegate.swift
@@ -39,7 +39,7 @@ protocol QuestionnaireDataSource: AnyObject {
 
     var viewModel: NINQuestionnaireViewModel! { get set }
     var sessionManager: NINChatSessionManager? { get set }
-    init(viewModel: NINQuestionnaireViewModel, sessionManager: NINChatSessionManager, delegate: InternalDelegate?)
+    init(viewModel: NINQuestionnaireViewModel, sessionManager: NINChatSessionManager, delegate: NINChatSessionInternalDelegate?)
 }
 
 protocol QuestionnaireDataSourceDelegate: QuestionnaireDataSource, QuestionnaireDelegate {}

--- a/NinchatSDKSwift/Implementations/Managers/NINChatSession Internal/NINChatSessionInternal.swift
+++ b/NinchatSDKSwift/Implementations/Managers/NINChatSession Internal/NINChatSessionInternal.swift
@@ -55,8 +55,6 @@ extension NINChatSession: NINChatSessionInternalDelegate {
     }
 
     func onResumeFailed() -> Bool {
-        weak var `self` = self
-        guard let `self` = self else { return false }
         return self.delegate?.ninchatDidFail(toResumeSession: self) ?? false
     }
 
@@ -87,9 +85,6 @@ extension NINChatSession: NINChatSessionInternalDelegate {
             .ninchatQuestionnaireBackground: .questionnaireBackground
         ]
 
-        weak var `self` = self
-        guard let `self` = self else { return nil }
-        
         if let asset = self.delegate?.ninchat(self, overrideImageAssetForKey: key) {
             return asset
         }
@@ -123,9 +118,6 @@ extension NINChatSession: NINChatSessionInternalDelegate {
             .ninchatColorRatingNegativeText: .ratingNegativeText
         ]
 
-        weak var `self` = self
-        guard let `self` = self else { return nil }
-        
         if let color = self.delegate?.ninchat(self, overrideColorAssetForKey: key) {
             return color
         }
@@ -134,9 +126,6 @@ extension NINChatSession: NINChatSessionInternalDelegate {
     }
 
     func override(layerAsset key: CALayerConstant) -> CALayer? {
-        weak var `self` = self
-        guard let `self` = self else { return nil }
-        
         let layer = self.delegate?.ninchat(self, overrideLayer: key)
         layer?.name = LAYER_NAME
         return layer
@@ -160,10 +149,7 @@ extension NINChatSession: NINChatSessionInternalDelegate {
             .ninchatQuestionnaireSelectSelected: .selectSelectedBackground,
             .ninchatQuestionnaireSelectUnselected: .selectDeselectedBackground
         ]
-        
-        weak var `self` = self
-        guard let `self` = self else { return nil }
-        
+                
         if let color = self.delegate?.ninchat(self, overrideQuestionnaireColorAssetKey: key) {
             return color
         }

--- a/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSeesionManagerPrivate.swift
+++ b/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSeesionManagerPrivate.swift
@@ -21,7 +21,9 @@ extension NINChatSessionManagerImpl {
             let realmQueues = param.realmQueue.value
             try realmQueues.accept(queuesParser)
 
-            self.queues.append(contentsOf: queuesParser.properties.keys.compactMap({ key in
+            self.queues.append(contentsOf: queuesParser.properties.keys.compactMap({ [weak self] key in
+                guard let `self` = self else { return nil }
+                
                 /// Add the queue only if it is not already available
                 guard !self.queues.contains(where: { $0.queueID == key } ) else { return nil }
                 
@@ -203,7 +205,8 @@ extension NINChatSessionManagerImpl {
         self.channelClosed = param.channelClosed.value || param.channelSuspended.value
         /// In case of "channel transfer", the corresponded function: "didPartChannel(param:)" is called after this function.
         /// Thus, We will send meta message only if the channel was actually closed, not parted.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+            guard let `self` = self else { return }
             guard self.channelClosed else { return }
 
             let text = self.translate(key: Constants.kConversationEnded.rawValue, formatParams: [:])

--- a/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSessionManagerClosures.swift
+++ b/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSessionManagerClosures.swift
@@ -19,12 +19,11 @@ extension NINChatSessionManagerImpl: NINChatSessionManagerClosureHandler {
         self.actionBoundClosures[id] = closure
         
         if self.onActionID == nil {
-            self.onActionID = { [weak self] result, error in
+            self.onActionID = { [weak self, id, closure] result, error in
                 if let targetClosure = self?.actionBoundClosures.filter({
                     guard case let .success(id) = result else { return false }
                     return $0.key == id
                 }).first?.value {
-                    
                     targetClosure(error)
                 }
             }
@@ -36,12 +35,11 @@ extension NINChatSessionManagerImpl: NINChatSessionManagerClosureHandler {
         self.actionFileBoundClosures[id] = closure
         
         if self.onActionFileInfo == nil {
-            self.onActionFileInfo = { [weak self] result, fileInfo, error in
+            self.onActionFileInfo = { [weak self, id, closure] result, fileInfo, error in
                 if let targetClosure = self?.actionFileBoundClosures.filter({
                     guard case let .success(id) = result else { return false }
                     return $0.key == id
                 }).first?.value {
-
                     targetClosure(error, fileInfo)
                 }
             }
@@ -53,12 +51,11 @@ extension NINChatSessionManagerImpl: NINChatSessionManagerClosureHandler {
         self.actionChannelBoundClosures[id] = closure
 
         if self.onActionChannel == nil {
-            self.onActionChannel = { [weak self] result, channelID in
+            self.onActionChannel = { [weak self, id, closure] result, channelID in
                 if let targetClosure = self?.actionChannelBoundClosures.filter({
                     guard case let .success(id) = result else { return false }
                     return $0.key == id
                 }).first?.value {
-
                     targetClosure(nil)
                 }
             }
@@ -70,7 +67,7 @@ extension NINChatSessionManagerImpl: NINChatSessionManagerClosureHandler {
         self.actionICEServersBoundClosures[id] = closure
 
         if self.onActionSevers == nil {
-            self.onActionSevers = { [weak self] result, stunServers, turnServers in
+            self.onActionSevers = { [weak self, id, closure] result, stunServers, turnServers in
                 if let targetClosure = self?.actionICEServersBoundClosures.filter({
                     guard case let .success(id) = result else { return false }
                     return $0.key == id

--- a/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSessionManagerClosures.swift
+++ b/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSessionManagerClosures.swift
@@ -19,7 +19,7 @@ extension NINChatSessionManagerImpl: NINChatSessionManagerClosureHandler {
         self.actionBoundClosures[id] = closure
         
         if self.onActionID == nil {
-            self.onActionID = { [weak self, id, closure] result, error in
+            self.onActionID = { [weak self] result, error in
                 if let targetClosure = self?.actionBoundClosures.filter({
                     guard case let .success(id) = result else { return false }
                     return $0.key == id
@@ -35,7 +35,7 @@ extension NINChatSessionManagerImpl: NINChatSessionManagerClosureHandler {
         self.actionFileBoundClosures[id] = closure
         
         if self.onActionFileInfo == nil {
-            self.onActionFileInfo = { [weak self, id, closure] result, fileInfo, error in
+            self.onActionFileInfo = { [weak self] result, fileInfo, error in
                 if let targetClosure = self?.actionFileBoundClosures.filter({
                     guard case let .success(id) = result else { return false }
                     return $0.key == id
@@ -51,7 +51,7 @@ extension NINChatSessionManagerImpl: NINChatSessionManagerClosureHandler {
         self.actionChannelBoundClosures[id] = closure
 
         if self.onActionChannel == nil {
-            self.onActionChannel = { [weak self, id, closure] result, channelID in
+            self.onActionChannel = { [weak self] result, channelID in
                 if let targetClosure = self?.actionChannelBoundClosures.filter({
                     guard case let .success(id) = result else { return false }
                     return $0.key == id
@@ -67,7 +67,7 @@ extension NINChatSessionManagerImpl: NINChatSessionManagerClosureHandler {
         self.actionICEServersBoundClosures[id] = closure
 
         if self.onActionSevers == nil {
-            self.onActionSevers = { [weak self, id, closure] result, stunServers, turnServers in
+            self.onActionSevers = { [weak self] result, stunServers, turnServers in
                 if let targetClosure = self?.actionICEServersBoundClosures.filter({
                     guard case let .success(id) = result else { return false }
                     return $0.key == id

--- a/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSessionManagerImpl.swift
+++ b/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSessionManagerImpl.swift
@@ -84,7 +84,7 @@ final class NINChatSessionManagerImpl: NSObject, NINChatSessionManager, NINChatD
 
     // MARK: - NINChatSessionManager
     
-    private(set) var audienceMetadata: NINLowLevelClientProps? {
+    private(set) weak var audienceMetadata: NINLowLevelClientProps? {
         set {
             NINLowLevelClientProps.saveMetadata(newValue)
         }
@@ -101,7 +101,7 @@ final class NINChatSessionManagerImpl: NSObject, NINChatSessionManager, NINChatD
     var audienceQueues: [Queue]! = []
     var siteConfiguration: SiteConfiguration!
     var givenConfiguration: NINSiteConfiguration?
-    var preAudienceQuestionnaireMetadata: NINLowLevelClientProps! {
+    weak var preAudienceQuestionnaireMetadata: NINLowLevelClientProps! {
         didSet {
             let metadata = self.audienceMetadata ?? NINLowLevelClientProps()
             metadata.set(value: preAudienceQuestionnaireMetadata, forKey: "pre_answers")
@@ -166,7 +166,10 @@ extension NINChatSessionManagerImpl {
     
     func fetchSiteConfiguration(config key: String, environments: [String]?, completion: @escaping CompletionWithError) {
         let request = SiteConfigRequest(serverAddress: self.serverAddress, configKey: key)
-        self.serviceManager.perform(request) { result in
+        
+        self.serviceManager.perform(request) { [weak self] result in
+            guard let `self` = self else { return }
+            
             switch result {
             case .success(let config):
                 debugger("Got site config: \(String(describing: config.toDictionary))")
@@ -191,7 +194,9 @@ extension NINChatSessionManagerImpl {
 
     internal func initiateSession(params: NINLowLevelClientProps, completion: @escaping CompletionWithCredentials) throws {
         /// Wait for the session creation event
-        self.onActionSessionEvent = { credentials, event, error in
+        self.onActionSessionEvent = { [weak self] credentials, event, error in
+            guard let `self` = self else { return }
+            
             if event == .sessionCreated {
                 if self.currentChannelID != nil {
                     completion(credentials, .toChannel, error); return
@@ -206,7 +211,9 @@ extension NINChatSessionManagerImpl {
         }
 
         /// Make sure our site configuration contains a realm_id
-        guard let realmId = self.siteConfiguration?.audienceRealm else { throw NINSessionExceptions.invalidRealmConfiguration }
+        guard let realmId = self.siteConfiguration?.audienceRealm else {
+            throw NINSessionExceptions.invalidRealmConfiguration
+        }
         self.realmID = realmId
 
         if let secret = self.siteSecret {

--- a/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSessionManagerImpl.swift
+++ b/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSessionManagerImpl.swift
@@ -92,7 +92,7 @@ final class NINChatSessionManagerImpl: NSObject, NINChatSessionManager, NINChatD
             NINLowLevelClientProps.loadMetadata()
         }
     }
-    var delegate: NINChatSessionInternalDelegate?
+    weak var delegate: NINChatSessionInternalDelegate?
     var queues: [Queue]! = [] {
         didSet {
             self.audienceQueues = self.queues

--- a/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSessionManagerImpl.swift
+++ b/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSessionManagerImpl.swift
@@ -20,7 +20,7 @@ protocol NINChatSessionManagerInternalActions {
 }
 
 final class NINChatSessionManagerImpl: NSObject, NINChatSessionManager, NINChatDevHelper, NINChatSessionManagerInternalActions {
-    internal let serviceManager = ServiceManager()
+    internal var serviceManager = ServiceManager()
     internal var channelUsers: [String:ChannelUser] = [:]
     internal var currentQueueID: String?
     internal var currentChannelID: String?

--- a/NinchatSDKSwift/Implementations/Models/ChatMessagePayload.swift
+++ b/NinchatSDKSwift/Implementations/Models/ChatMessagePayload.swift
@@ -22,16 +22,16 @@ struct FileAttributes: Decodable {
     }
 }
 
-final class Attributes: Decodable {
-    var name: String!
-    var type: String!
-    var size: Int!
+struct Attributes: Decodable {
+    var name: String = ""
+    var type: String = ""
+    var size: Int = 0
     
     enum CodingKeys: String, CodingKey {
         case name, type, size
     }
     
-    required init(from decoder: Decoder) throws {
+    init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
         name = try container.decode(String.self, forKey: .name)

--- a/NinchatSDKSwift/Implementations/Models/FileInfo.swift
+++ b/NinchatSDKSwift/Implementations/Models/FileInfo.swift
@@ -63,15 +63,16 @@ final class FileInfo: Codable {
         debugger("Must update file info; call describe_file with id: \(self.fileID ?? "") and name: \(self.name ?? "")")
         do {
             try session?.describe(file: self.fileID) { [weak self] error, fileInfo in
-                debugger("described file with id: \(self?.fileID ?? "nil") and name: \(self?.name ?? "")")
+                guard let `self` = self else { return }
+                debugger("described file with id: \(self.fileID ?? "nil") and name: \(self.name ?? "")")
 
                 if let error = error {
                     completion(error, false)
                 } else if let info = fileInfo {
-                    self?.url = info["url"] as? String
-                    self?.urlExpiry = info["urlExpiry"] as? Date
-                    self?.thumbnailUrl = info["thumbnailUrl"] as? String
-                    self?.aspectRatio = info["aspectRatio"] as? Double
+                    self.url = info["url"] as? String
+                    self.urlExpiry = info["urlExpiry"] as? Date
+                    self.thumbnailUrl = info["thumbnailUrl"] as? String
+                    self.aspectRatio = info["aspectRatio"] as? Double
                     completion(nil, true)
                 }
             }

--- a/NinchatSDKSwift/Implementations/Models/RTCSignal.swift
+++ b/NinchatSDKSwift/Implementations/Models/RTCSignal.swift
@@ -36,11 +36,11 @@ enum MessageType: String, Decodable {
     }
 }
 
-final class RTCSignal: Codable {
+struct RTCSignal: Codable {
     let candidate: [String:String]?
     let sdp: [String:String]?
     
-    required init(from decoder: Decoder) throws {
+    init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
         candidate = try container.decodeIfPresent([String:AnyCodable].self, forKey: .candidate)?.reduce(into: [:]) { (dic: inout [String:String], item) in

--- a/NinchatSDKSwift/Implementations/Models/SiteConfiguration.swift
+++ b/NinchatSDKSwift/Implementations/Models/SiteConfiguration.swift
@@ -117,9 +117,8 @@ struct SiteConfigurationImpl: SiteConfiguration {
 
     // MARK: - PreAudience Questionnaire
     var preAudienceQuestionnaireStyle: QuestionnaireStyle {
-        guard let style = self.value(for: "preAudienceQuestionnaireStyle", ofType: String.self),
-              style != nil
-        else { return .form }
+        guard let style = self.value(for: "preAudienceQuestionnaireStyle", ofType: String.self), !style.isEmpty
+            else { return .form }
         
         return QuestionnaireStyle(rawValue: style.lowercased()) ?? .form
     }
@@ -135,9 +134,8 @@ struct SiteConfigurationImpl: SiteConfiguration {
 
     // MARK: - PostAudience Questionnaire
     var postAudienceQuestionnaireStyle: QuestionnaireStyle {
-        guard let style = self.value(for: "postAudienceQuestionnaireStyle", ofType: String.self),
-              style != nil
-        else { return .form }
+        guard let style = self.value(for: "postAudienceQuestionnaireStyle", ofType: String.self), !style.isEmpty
+            else { return .form }
         
         return QuestionnaireStyle(rawValue: style.lowercased()) ?? .form
     }
@@ -177,6 +175,6 @@ extension SiteConfigurationImpl {
         debugger("Loading keys from environments: \(environments)")
 
         /// Start the lookup
-        return environments.compactMap({ (configuration[$0] as? [String:Any])?[key] as? T }).first(where: { $0 != nil })
+        return environments.compactMap({ (configuration[$0] as? [String:Any])?[key] as? T }).first
     }
 }

--- a/NinchatSDKSwift/Implementations/View Model/NINChatViewModel.swift
+++ b/NinchatSDKSwift/Implementations/View Model/NINChatViewModel.swift
@@ -55,7 +55,7 @@ protocol NINChatAttachmentProtocol {
     func openAttachment(source: UIImagePickerController.SourceType, completion: @escaping AttachmentCompletion)
 }
 
-protocol NINChatViewModel: NINChatRTCProtocol, NINChatStateProtocol, NINChatMessageProtocol, NINChatPermissionsProtocol, NINChatAttachmentProtocol {
+protocol NINChatViewModel: AnyObject, NINChatRTCProtocol, NINChatStateProtocol, NINChatMessageProtocol, NINChatPermissionsProtocol, NINChatAttachmentProtocol {
     var onChannelClosed: (() -> Void)? { get set }
     var onQueueUpdated: (() -> Void)? { get set }
     var onChannelMessage: ((MessageUpdateType) -> Void)? { get set }

--- a/NinchatSDKSwift/Implementations/View Model/NINFullScreenViewModel.swift
+++ b/NinchatSDKSwift/Implementations/View Model/NINFullScreenViewModel.swift
@@ -13,7 +13,7 @@ protocol NINFullScreenViewModel {
 
 final class NINFullScreenViewModelImpl: NSObject, NINFullScreenViewModel {
     
-    private var delegate: NINChatSessionInternalDelegate?
+    private weak var delegate: NINChatSessionInternalDelegate?
     private var downloadCompletion: ((Error?) -> Void)?
     
     // MARK: - NINFullScreenViewModel

--- a/NinchatSDKSwift/Implementations/View Model/NINQueueViewModel.swift
+++ b/NinchatSDKSwift/Implementations/View Model/NINQueueViewModel.swift
@@ -20,7 +20,7 @@ protocol NINQueueViewModel {
 final class NINQueueViewModelImpl: NINQueueViewModel {
     
     private unowned var sessionManager: NINChatSessionManager!
-    private var delegate: NINChatSessionInternalDelegate?
+    private weak var delegate: NINChatSessionInternalDelegate?
     private var readyToJoin: Bool = false
 
     // MARK: - NINQueueViewModel

--- a/NinchatSDKSwift/Implementations/View/Coordinator/Coordinator.swift
+++ b/NinchatSDKSwift/Implementations/View/Coordinator/Coordinator.swift
@@ -22,7 +22,7 @@ final class NINCoordinator: NSObject, Coordinator, UIAdaptivePresentationControl
     // MARK: - Coordinator
 
     internal var delegate: InternalDelegate?
-    internal var sessionManager: NINChatSessionManager!
+    internal weak var sessionManager: NINChatSessionManager!
     internal var onPresentationCompletion: (() -> Void)?
     internal weak var navigationController: UINavigationController? {
         didSet {
@@ -88,8 +88,8 @@ final class NINCoordinator: NSObject, Coordinator, UIAdaptivePresentationControl
         joinViewController.sessionManager = sessionManager
         joinViewController.onQueueActionTapped = { [weak self] queue in
             DispatchQueue.main.async {
-                guard let weakSelf = self else { return }
-                weakSelf.navigationController?.pushViewController(weakSelf.chatViewController(queue: queue), animated: true)
+                guard let `self` = self else { return }
+                self.navigationController?.pushViewController(self.chatViewController(queue: queue), animated: true)
             }
         }
 
@@ -178,8 +178,8 @@ final class NINCoordinator: NSObject, Coordinator, UIAdaptivePresentationControl
     // MARK: - Coordinator
 
     init(with sessionManager: NINChatSessionManager, delegate: InternalDelegate?, onPresentationCompletion: @escaping (() -> Void)) {
-        self.sessionManager = sessionManager
         self.delegate = delegate
+        self.sessionManager = sessionManager
         self.onPresentationCompletion = onPresentationCompletion
     }
 
@@ -295,11 +295,13 @@ extension NINCoordinator {
                 weakSelf.navigationController?.pushViewController(weakSelf.fullScreenViewController(image: image, attachment: attachment), animated: true)
             }
         }
-        dataSourceDelegate.onOpenVideoAttachment = { attachment in
+        dataSourceDelegate.onOpenVideoAttachment = { [weak self] attachment in
             guard let attachmentURL = attachment.url, let playerURL = URL(string: attachmentURL) else { return }
+            
             let playerViewController = AVPlayerViewController()
             playerViewController.player = AVPlayer(url: playerURL)
-            self.navigationController?.present(playerViewController, animated: true) {
+            
+            self?.navigationController?.present(playerViewController, animated: true) {
                 playerViewController.player?.play()
             }
         }

--- a/NinchatSDKSwift/Implementations/View/Coordinator/Coordinator.swift
+++ b/NinchatSDKSwift/Implementations/View/Coordinator/Coordinator.swift
@@ -11,7 +11,7 @@ import WebRTC
 import NinchatLowLevelClient
 
 protocol Coordinator: AnyObject {
-    init(with sessionManager: NINChatSessionManager, delegate: InternalDelegate?, onPresentationCompletion: @escaping (() -> Void))
+    init(with sessionManager: NINChatSessionManager, delegate: NINChatSessionInternalDelegate?, onPresentationCompletion: @escaping (() -> Void))
     func start(with queue: String?, resume: ResumeMode?, within navigation: UINavigationController?) -> UIViewController?
     func prepareNINQuestionnaireViewModel(audienceMetadata: NINLowLevelClientProps?, onCompletion: @escaping (() -> Void))
     func deallocate()
@@ -21,7 +21,7 @@ final class NINCoordinator: NSObject, Coordinator, UIAdaptivePresentationControl
 
     // MARK: - Coordinator
 
-    internal var delegate: InternalDelegate?
+    internal weak var delegate: NINChatSessionInternalDelegate?
     internal weak var sessionManager: NINChatSessionManager!
     internal var onPresentationCompletion: (() -> Void)?
     internal weak var navigationController: UINavigationController? {
@@ -177,7 +177,7 @@ final class NINCoordinator: NSObject, Coordinator, UIAdaptivePresentationControl
 
     // MARK: - Coordinator
 
-    init(with sessionManager: NINChatSessionManager, delegate: InternalDelegate?, onPresentationCompletion: @escaping (() -> Void)) {
+    init(with sessionManager: NINChatSessionManager, delegate: NINChatSessionInternalDelegate?, onPresentationCompletion: @escaping (() -> Void)) {
         self.delegate = delegate
         self.sessionManager = sessionManager
         self.onPresentationCompletion = onPresentationCompletion

--- a/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Meta Cell/ChatMetaCell.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Meta Cell/ChatMetaCell.swift
@@ -21,7 +21,7 @@ final class ChatMetaCell: UITableViewCell, ChatMeta {
     
     // MARK: - ChatMeta
     
-    var delegate: NINChatSessionInternalDelegate?
+    weak var delegate: NINChatSessionInternalDelegate?
     var onCloseChatTapped: ((Button) -> Void)?
     
     func populate(message: MetaMessage, colorAssets: NINColorAssetDictionary?) {

--- a/NinchatSDKSwift/Implementations/View/UIKit/Confirm View/ConfirmCloseChatView.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Confirm View/ConfirmCloseChatView.swift
@@ -28,8 +28,8 @@ final class ConfirmCloseChatView: UIView, HasCustomLayer, ConfirmView {
     // MARK: - ConfirmView
     
     var onViewAction: OnViewAction?
-    var delegate: InternalDelegate?
-    var sessionManager: NINChatSessionManager? {
+    weak var delegate: NINChatSessionInternalDelegate?
+    weak var sessionManager: NINChatSessionManager? {
         didSet {
             self.overrideAssets()
         }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Confirm View/ConfirmVideoCallView.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Confirm View/ConfirmVideoCallView.swift
@@ -49,8 +49,8 @@ final class ConfirmVideoCallView: UIView, ConfirmVideoCallViewProtocol, HasCusto
     // MARK: - ConfirmView
     
     var onViewAction: OnViewAction?
-    var delegate: InternalDelegate?
-    var sessionManager: NINChatSessionManager? {
+    weak var delegate: NINChatSessionInternalDelegate?
+    weak var sessionManager: NINChatSessionManager? {
         didSet {
             self.overrideAssets()
         }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Confirm View/ConfirmView.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Confirm View/ConfirmView.swift
@@ -14,7 +14,7 @@ enum ConfirmAction {
 protocol ConfirmView where Self:UIView {
     typealias OnViewAction = ((ConfirmAction) -> Void)
     var onViewAction: OnViewAction? { get set }
-    var delegate: InternalDelegate? { get set }
+    var delegate: NINChatSessionInternalDelegate? { get set }
     var sessionManager: NINChatSessionManager? { get set }
     
     func showConfirmView(on view: UIView)

--- a/NinchatSDKSwift/Implementations/View/UIKit/Faces View/FacesView.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Faces View/FacesView.swift
@@ -13,7 +13,7 @@ protocol FacesViewActions {
 }
 
 protocol FacesViewProtocol: UIView, FacesViewActions {
-    var delegate: InternalDelegate? { get set }
+    var delegate: NINChatSessionInternalDelegate? { get set }
     var sessionManager: NINChatSessionManager? { get set }
 
     func overrideAssets()
@@ -23,7 +23,7 @@ final class FacesView: UIView, FacesViewProtocol {
     
     // MARK: - FacesViewProtocol
 
-    var delegate: InternalDelegate?
+    weak var delegate: NINChatSessionInternalDelegate?
     weak var sessionManager: NINChatSessionManager?
     
     // MARK: - Outlets

--- a/NinchatSDKSwift/Implementations/View/UIKit/Input Controls/ChatInputControls.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Input Controls/ChatInputControls.swift
@@ -16,7 +16,7 @@ protocol ChatInputActions {
 }
 
 protocol ChatInputControlsProtocol: UIView, ChatInputActions {
-    var delegate: InternalDelegate? { get set }
+    var delegate: NINChatSessionInternalDelegate? { get set }
     var sessionManager: NINChatSessionManager? { get set }
     var viewModel: NINChatViewModel! { get set }
     var isSelected: Bool! { get set }
@@ -44,7 +44,7 @@ final class ChatInputControls: UIView, HasCustomLayer, ChatInputControlsProtocol
 
     // MARK: - ChatInputControls
 
-    var delegate: InternalDelegate?
+    weak var delegate: NINChatSessionInternalDelegate?
     weak var sessionManager: NINChatSessionManager?
 
     var viewModel: NINChatViewModel!

--- a/NinchatSDKSwift/Implementations/View/UIKit/Input Controls/ChatInputControls.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Input Controls/ChatInputControls.swift
@@ -95,7 +95,9 @@ final class ChatInputControls: UIView, HasCustomLayer, ChatInputControlsProtocol
             sendMessageButton.layer.insertSublayer(layer, below: sendMessageButton.titleLabel?.layer)
         }
         /// TODO: REMOVE legacy delegate
-        else if let sendButtonTitle = self.sessionManager?.siteConfiguration.sendButtonTitle {
+        else if self.sessionManager?.siteConfiguration.sendButtonTitle != nil {
+            /// the title is set by a few lines above
+            
             if let backgroundColor = self.delegate?.override(colorAsset: .textareaSubmit) {
                 self.sendMessageButton.backgroundColor = backgroundColor
             }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementRadio.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementRadio.swift
@@ -74,7 +74,7 @@ class QuestionnaireElementRadio: UIView, HasCustomLayer, QuestionnaireElementWit
 
     // MARK: - Subviews - QuestionnaireElementWithTitleAndOptions + QuestionnaireElementHasButtons
 
-    private var delegate: NINChatSessionInternalDelegate?
+    private weak var delegate: NINChatSessionInternalDelegate?
     private(set) lazy var title: UILabel = {
         UILabel(frame: .zero)
     }()

--- a/NinchatSDKSwift/Implementations/View/UIKit/Top Bar/TopBar.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Top Bar/TopBar.swift
@@ -12,7 +12,7 @@ protocol TopBarAction {
 }
 
 protocol TopBarProtocol: UIView, TopBarAction {
-    var delegate: InternalDelegate? { get set }
+    var delegate: NINChatSessionInternalDelegate? { get set }
     var fileName: String! { get set }
     
     func overrideAssets()
@@ -22,7 +22,7 @@ final class TopBar: UIView, TopBarProtocol, HasCustomLayer {
     
     // MARK: - TopBarProtocol
 
-    var delegate: InternalDelegate?
+    weak var delegate: NINChatSessionInternalDelegate?
     var fileName: String! {
         didSet {
             fileNameLabel.text = fileName

--- a/NinchatSDKSwift/Implementations/View/UIKit/Video View/VideoView.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Video View/VideoView.swift
@@ -15,7 +15,7 @@ protocol VideoViewActions {
 }
 
 protocol VideoViewProtocol: UIView, VideoViewActions {
-    var delegate: InternalDelegate? { get set }
+    var delegate: NINChatSessionInternalDelegate? { get set }
     var viewModel: NINChatViewModel! { get set }
     var localCapture: RTCCameraVideoCapturer? { get set }
     var remoteCapture: RTCVideoRenderer? { get set }
@@ -33,7 +33,7 @@ final class VideoView: UIView, VideoViewProtocol {
     
     // MARK: - VideoViewProtocol
 
-    var delegate: InternalDelegate?
+    weak var delegate: NINChatSessionInternalDelegate?
     var viewModel: NINChatViewModel!
     var onHangupTapped: Action?
     var onAudioTapped: Action?

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINChatViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINChatViewController.swift
@@ -11,7 +11,7 @@ final class NINChatViewController: UIViewController, KeyboardHandler {
 
     // MARK: - ViewController
 
-    var delegate: InternalDelegate?
+    weak var delegate: NINChatSessionInternalDelegate?
     weak var sessionManager: NINChatSessionManager?
 
     // MARK: - Injected

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINFullScreenViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINFullScreenViewController.swift
@@ -17,7 +17,7 @@ final class NINFullScreenViewController: UIViewController, ViewController {
     
     // MARK: - ViewController
     
-    var delegate: InternalDelegate?
+    weak var delegate: NINChatSessionInternalDelegate?
     weak var sessionManager: NINChatSessionManager?
     
     // MARK: - Outlets

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINInitialViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINInitialViewController.swift
@@ -54,10 +54,6 @@ final class NINInitialViewController: UIViewController, HasCustomLayer, ViewCont
 
     // MARK: - UIViewController
     
-    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        .portrait
-    }
-    
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINInitialViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINInitialViewController.swift
@@ -14,7 +14,7 @@ final class NINInitialViewController: UIViewController, HasCustomLayer, ViewCont
     
     // MARK: - ViewController
     
-    var delegate: InternalDelegate?
+    weak var delegate: NINChatSessionInternalDelegate?
     weak var sessionManager: NINChatSessionManager?
     
     // MARK: - Outlets

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINInitialViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINInitialViewController.swift
@@ -131,7 +131,7 @@ private extension NINInitialViewController {
         let buttonHeights: CGFloat = (numberOfButtons > 2) ? 40.0 : 60.0
         for index in 0..<numberOfButtons {
             let queue = uniqueQueus[index]
-            let button = Button(frame: .zero) { [weak self] _ in
+            let button = Button(frame: .zero) { [weak self, queue] _ in
                 self?.onQueueActionTapped?(queue)
             }
             button.translatesAutoresizingMaskIntoConstraints = false

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINQuestionnaireViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINQuestionnaireViewController.swift
@@ -54,7 +54,7 @@ final class NINQuestionnaireViewController: UIViewController, ViewController, Ke
 
     // MARK: - ViewController
 
-    var delegate: InternalDelegate?
+    weak var delegate: NINChatSessionInternalDelegate?
     weak var sessionManager: NINChatSessionManager?
 
     // MARK: - Injected

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINQueueViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINQueueViewController.swift
@@ -55,10 +55,6 @@ final class NINQueueViewController: UIViewController, HasCustomLayer, ViewContro
     
     // MARK: - UIViewController
     
-    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        .portrait
-    }
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         self.overrideAssets()

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINQueueViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINQueueViewController.swift
@@ -18,7 +18,7 @@ final class NINQueueViewController: UIViewController, HasCustomLayer, ViewContro
     
     // MARK: - ViewController
     
-    var delegate: InternalDelegate?
+    weak var delegate: NINChatSessionInternalDelegate?
     weak var sessionManager: NINChatSessionManager?
     
     // MARK: - Outlets

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINRatingViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINRatingViewController.swift
@@ -63,11 +63,7 @@ final class NINRatingViewController: UIViewController, HasCustomLayer, ViewContr
     @IBOutlet private(set) weak var facesFormViewContainer: UIView!
      
     // MARK: - UIViewController
-    
-    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        return .portrait
-    }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINRatingViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINRatingViewController.swift
@@ -16,7 +16,7 @@ final class NINRatingViewController: UIViewController, HasCustomLayer, ViewContr
     
     // MARK: - ViewController
 
-    var delegate: InternalDelegate?
+    weak var delegate: NINChatSessionInternalDelegate?
     weak var sessionManager: NINChatSessionManager?
     var onRatingFinished: ((ChatStatus?) -> Bool)!
     

--- a/NinchatSDKSwift/Implementations/View/ViewController/ViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/ViewController.swift
@@ -7,6 +7,6 @@
 import UIKit
 
 protocol ViewController: UIViewController {
-    var delegate: InternalDelegate? { get set }
+    var delegate: NINChatSessionInternalDelegate? { get set }
     var sessionManager: NINChatSessionManager? { get set }
 }

--- a/NinchatSDKSwift/NINChatSession.swift
+++ b/NinchatSDKSwift/NINChatSession.swift
@@ -92,7 +92,6 @@ public final class NINChatSession: NINChatSessionProtocol, NINChatDevHelper {
         self.audienceMetadata = metadata
         self.configuration = configuration
         self.serverAddress = Constants.kProductionServerAddress.rawValue
-        self.started = false
     }
 
     deinit {

--- a/NinchatSDKSwift/NINChatSession.swift
+++ b/NinchatSDKSwift/NINChatSession.swift
@@ -39,13 +39,10 @@ extension NINChatSessionProtocol {
 
 public final class NINChatSession: NINChatSessionProtocol, NINChatDevHelper {
     lazy var sessionManager: NINChatSessionManager! = {
-        NINChatSessionManagerImpl(session: self.internalDelegate, serverAddress: self.defaultServerAddress, audienceMetadata: self.audienceMetadata, configuration: self.configuration)
-    }()
-    lazy var internalDelegate: InternalDelegate? = {
-        InternalDelegate(session: self)
+        NINChatSessionManagerImpl(session: self, serverAddress: self.defaultServerAddress, audienceMetadata: self.audienceMetadata, configuration: self.configuration)
     }()
     private lazy var coordinator: Coordinator? = {
-        NINCoordinator(with: self.sessionManager, delegate: self.internalDelegate) { [weak self] in
+        NINCoordinator(with: self.sessionManager, delegate: self) { [weak self] in
             self?.deallocate()
         }
     }()
@@ -181,7 +178,7 @@ public final class NINChatSession: NINChatSessionProtocol, NINChatDevHelper {
         self.sessionManager = nil
         self.started = false
         self.sessionAlive = false
-        self.internalDelegate?.onDidEnd()
+        self.onDidEnd()
     }
 }
 
@@ -273,7 +270,7 @@ extension NINChatSession {
     }
 
     private func handleResumptionFailure(completion: @escaping NinchatSessionCompletion) throws {
-        if self.internalDelegate?.onResumeFailed() ?? false {
+        if self.onResumeFailed() {
             /// Automatically start a new session
             try self.openChatSession(completion: completion)
         } else {

--- a/NinchatSDKSwift/NINChatSession.swift
+++ b/NinchatSDKSwift/NINChatSession.swift
@@ -208,13 +208,13 @@ extension NINChatSession {
         /// queues mentioned in "preAudienceQuestionnaire" as a target under the "queueId" key
         if let preAuestionnaireQueues = self.sessionManager.siteConfiguration.preAudienceQuestionnaireDictionary?.reduce(into: [], { (queues: inout [String], dict) in
             queues.append(contentsOf: dict.find("queueId"))
-        }).compactMap({ $0 as? String }), !preAuestionnaireQueues.isEmpty {
+        }).compactMap({ $0 }), !preAuestionnaireQueues.isEmpty {
             queues.append(contentsOf: preAuestionnaireQueues)
         }
         /// queues mentioned in "postAudienceQuestionnaire" as a target under the "queueId" key
         if let postAuestionnaireQueues = self.sessionManager.siteConfiguration.preAudienceQuestionnaireDictionary?.reduce(into: [], { (queues: inout [String], dict) in
             queues.append(contentsOf: dict.find("queueId"))
-        }).compactMap({ $0 as? String }), !postAuestionnaireQueues.isEmpty {
+        }).compactMap({ $0 }), !postAuestionnaireQueues.isEmpty {
             queues.append(contentsOf: postAuestionnaireQueues)
         }
 

--- a/NinchatSDKSwift/NINChatSession.swift
+++ b/NinchatSDKSwift/NINChatSession.swift
@@ -46,8 +46,8 @@ public final class NINChatSession: NINChatSessionProtocol, NINChatDevHelper {
             self?.deallocate()
         }
     }()
-    private let audienceMetadata: NINLowLevelClientProps?
-    private let configuration: NINSiteConfiguration?
+    private weak var audienceMetadata: NINLowLevelClientProps?
+    private var configuration: NINSiteConfiguration?
     private var configKey: String!
     private var queueID: String?
     private var environments: [String]?
@@ -109,13 +109,13 @@ public final class NINChatSession: NINChatSessionProtocol, NINChatDevHelper {
             try self.fetchSiteConfiguration { [weak self] error in
                 DispatchQueue.main.async {
                     do {
-                        try self?.openChatSession() { credentials, error in
-                            guard let weakSelf = self, error == nil else { completion(credentials, error); return }
+                        try self?.openChatSession() { [weak self] credentials, error in
+                            guard let `self` = self, error == nil else { completion(credentials, error); return }
 
                             /// Prepare coordinator for starting
                             /// This is quite important to prepare time and memory consuming tasks before the user
                             /// starts the coordinator, otherwise he/she will face unexpected views
-                            weakSelf.coordinator?.prepareNINQuestionnaireViewModel(audienceMetadata: weakSelf.audienceMetadata) {
+                            self.coordinator?.prepareNINQuestionnaireViewModel(audienceMetadata: self.audienceMetadata) {
                                 completion(credentials, error)
                             }
                         }
@@ -136,13 +136,13 @@ public final class NINChatSession: NINChatSessionProtocol, NINChatDevHelper {
             try self.fetchSiteConfiguration { [weak self] error in
                 DispatchQueue.main.async {
                     do {
-                        try self?.openChatSession(credentials: credentials) { credentials, error in
-                            guard let weakSelf = self, error == nil else { completion(credentials, error); return }
+                        try self?.openChatSession(credentials: credentials) { [weak self] credentials, error in
+                            guard let `self` = self, error == nil else { completion(credentials, error); return }
 
                             /// Prepare coordinator for starting
                             /// This is quite important to prepare time and memory consuming tasks before the user
                             /// starts the coordinator, otherwise he/she will face unexpected views
-                            weakSelf.coordinator?.prepareNINQuestionnaireViewModel(audienceMetadata: weakSelf.audienceMetadata) {
+                            self.coordinator?.prepareNINQuestionnaireViewModel(audienceMetadata: self.audienceMetadata) {
                                 completion(credentials, error)
                             }
                         }

--- a/NinchatSDKSwiftTests/CoordinatorTests.swift
+++ b/NinchatSDKSwiftTests/CoordinatorTests.swift
@@ -14,7 +14,7 @@ class CoordinatorTests: XCTestCase {
     
 
     override func setUp() {
-        coordinator = NINCoordinator(with: session.sessionManager, delegate: session.internalDelegate) { }
+        coordinator = NINCoordinator(with: session.sessionManager, delegate: session) { }
     }
 
     override func tearDown() { }

--- a/NinchatSDKSwiftTests/NINChatViewModelTests.swift
+++ b/NinchatSDKSwiftTests/NINChatViewModelTests.swift
@@ -20,8 +20,7 @@ class NINChatViewModelTests: XCTestCase, NINChatWebRTCClientDelegate {
     var onError: ((NINChatWebRTCClient, Error) -> Void)?
 
     override func setUp() {
-        let delegate = InternalDelegate(session: NINChatSession(configKey: ""))
-        sessionManager = NINChatSessionManagerImpl(session: delegate, serverAddress: "", configuration: nil)
+        sessionManager = NINChatSessionManagerImpl(session: NINChatSession(configKey: ""), serverAddress: "", configuration: nil)
         viewModel = NINChatViewModelImpl(sessionManager: sessionManager)
     }
 

--- a/NinchatSDKSwiftTests/NinchatSessionManagerTests.swift
+++ b/NinchatSDKSwiftTests/NinchatSessionManagerTests.swift
@@ -16,7 +16,7 @@ class NinchatSessionManagerTests: XCTestCase {
     
     override func setUp() {
         sessionSwift = NINChatSession(configKey: "")
-        sessionManager = NINChatSessionManagerImpl(session: InternalDelegate(session: sessionSwift), serverAddress: "", audienceMetadata: NINLowLevelClientProps.initiate(metadata: ["metadata":"value"]) ,configuration: nil)
+        sessionManager = NINChatSessionManagerImpl(session: sessionSwift, serverAddress: "", audienceMetadata: NINLowLevelClientProps.initiate(metadata: ["metadata":"value"]) ,configuration: nil)
     }
 
     override func tearDown() { }
@@ -46,7 +46,7 @@ class NinchatSessionManagerPrivateTests: XCTestCase {
     
     override func setUp() {
         sessionSwift = NINChatSession(configKey: "")
-        sessionManager = NINChatSessionManagerImpl(session: InternalDelegate(session: sessionSwift), serverAddress: "", configuration: nil)
+        sessionManager = NINChatSessionManagerImpl(session: sessionSwift, serverAddress: "", configuration: nil)
     }
 
     func testIndexOfItem() {
@@ -154,7 +154,7 @@ class NinchatSessionManagerClosureHandlersTests: XCTestCase {
     
     override func setUp() {
         sessionSwift = NINChatSession(configKey: "")
-        sessionManager = NINChatSessionManagerImpl(session: InternalDelegate(session: sessionSwift), serverAddress: "", configuration: nil)
+        sessionManager = NINChatSessionManagerImpl(session: sessionSwift, serverAddress: "", configuration: nil)
     }
 
     func testBindFailure() {

--- a/NinchatSDKSwiftTests/QuestionnaireDataSourceDelegateTests.swift
+++ b/NinchatSDKSwiftTests/QuestionnaireDataSourceDelegateTests.swift
@@ -42,8 +42,8 @@ final class QuestionnaireDataSourceDelegateTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        formQuestionnaireDataSource = NINQuestionnaireFormDataSourceDelegate(viewModel: viewModel, sessionManager: self.session.sessionManager, delegate: self.session.internalDelegate)
-        conversationQuestionnaireDataSource = NINQuestionnaireConversationDataSourceDelegate(viewModel: viewModel, sessionManager: self.session.sessionManager, delegate: self.session.internalDelegate)
+        formQuestionnaireDataSource = NINQuestionnaireFormDataSourceDelegate(viewModel: viewModel, sessionManager: self.session.sessionManager, delegate: self.session)
+        conversationQuestionnaireDataSource = NINQuestionnaireConversationDataSourceDelegate(viewModel: viewModel, sessionManager: self.session.sessionManager, delegate: self.session)
     }
 
     private var formQuestionnaireDataSource: QuestionnaireDataSourceDelegate!

--- a/NinchatSDKSwiftTests/UIKitTests.swift
+++ b/NinchatSDKSwiftTests/UIKitTests.swift
@@ -15,7 +15,7 @@ final class UIKitTests: XCTestCase {
     
     override func setUp() {
         sessionSwift = NINChatSession(configKey: "")
-        sessionManager = NINChatSessionManagerImpl(session: InternalDelegate(session: sessionSwift), serverAddress: "", configuration: nil)
+        sessionManager = NINChatSessionManagerImpl(session: sessionSwift, serverAddress: "", configuration: nil)
     }
     
     func test_confirmView() {


### PR DESCRIPTION
A bunch of improvements in managing memory cycles in different modules, including:

- ViewController: remove retain-cycle
- DataSource/Delegate: remove retain-cycle
- InternalDelegate: improve how the internal delegate works
- Managers: add missing captures for many cases
- ServiceManager: fix a known memory leakage for URLSession
- remove dead code
- change 'class' to 'struct' for models
