### PR TITLE
questionnaire/fix bool answer

### DIFF
--- a/NinchatSDKSwift/Implementations/Extensions/NINLowLevelClientProps+Extension.swift
+++ b/NinchatSDKSwift/Implementations/Extensions/NINLowLevelClientProps+Extension.swift
@@ -566,14 +566,14 @@ extension NINLowLevelClientProps {
     func set<T>(value: T, forKey key: String) {
         if let value = value as? AnyCodable {
             self.set(value: value.value as! AnyHashable, forKey: key)
+        } else if let value = value as? Bool {
+            self.setBool(key, val: value)
         } else if let value = value as? Double, floor(value) == value {
             self.setInt(key, val: Int(value))
         } else if let value = value as? Double {
             self.setFloat(key, val: value)
         } else if let value = value as? Int {
             self.setInt(key, val: value)
-        } else if let value = value as? Bool {
-            self.setBool(key, val: value)
         } else if let value = value as? String {
             self.setString(key, val: value)
         } else if let value = value as? NINLowLevelClientProps {


### PR DESCRIPTION
When a bool value is passed to the function, it was saved as integer
since Int(value) is always a valid experssion. The commit fixes the
issue by re-ordering type check with bool check in the first priority.
