### PR TITLE
compose/fix reuse cell

### DIFF
--- a/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSeesionManagerPrivate.swift
+++ b/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSeesionManagerPrivate.swift
@@ -398,7 +398,8 @@ extension NINChatSessionManagerImpl {
     }
 
     internal func applyCompose(action: ComposeUIAction, to message: ComposeMessage) {
-        self.onComposeActionUpdated?(self.chatMessages.firstIndex(where: { $0.messageID == message.messageID }) ?? -1, action)
+        /// use message id instead of index, as the index for the last message is always 0
+        self.onComposeActionUpdated?(message.messageID, action)
         self.composeActions.removeAll(where: { $0.target == action.target })
     }
     

--- a/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSessionManager.swift
+++ b/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSessionManager.swift
@@ -136,7 +136,7 @@ protocol NINChatSessionManagerDelegate: AnyObject {
     var onChannelClosed: (() -> Void)? { get set }
     var onRTCSignal: ((MessageType, ChannelUser?, _ signal: RTCSignal?) -> Void)? { get set }
     var onRTCClientSignal: ((MessageType, ChannelUser?, _ signal: RTCSignal?) -> Void)? { get set }
-    var onComposeActionUpdated: ((_ index: Int, _ action: ComposeUIAction) -> Void)? { get set }
+    var onComposeActionUpdated: ((_ id: String, _ action: ComposeUIAction) -> Void)? { get set }
 
     func bindQueueUpdate<T: QueueUpdateCapture>(closure: @escaping (Events, Queue, Error?) -> Void, to receiver: T)
     func unbindQueueUpdateClosure<T: QueueUpdateCapture>(from receiver: T)

--- a/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSessionManagerImpl.swift
+++ b/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSessionManagerImpl.swift
@@ -72,7 +72,7 @@ final class NINChatSessionManagerImpl: NSObject, NINChatSessionManager, NINChatD
     var onChannelClosed: (() -> Void)?
     var onRTCSignal: ((MessageType, ChannelUser?, _ signal: RTCSignal?) -> Void)?
     var onRTCClientSignal: ((MessageType, ChannelUser?, _ signal: RTCSignal?) -> Void)?
-    var onComposeActionUpdated: ((_ index: Int, _ action: ComposeUIAction) -> Void)?
+    var onComposeActionUpdated: ((_ id: String, _ action: ComposeUIAction) -> Void)?
     
     func bindQueueUpdate<T: QueueUpdateCapture>(closure: @escaping (Events, Queue, Error?) -> Void, to receiver: T) {
         guard queueUpdateBoundClosures.keys.filter({ $0 == receiver.desc }).count == 0 else { return }

--- a/NinchatSDKSwift/Implementations/View Model/NINChatViewModel.swift
+++ b/NinchatSDKSwift/Implementations/View Model/NINChatViewModel.swift
@@ -59,7 +59,7 @@ protocol NINChatViewModel: AnyObject, NINChatRTCProtocol, NINChatStateProtocol, 
     var onChannelClosed: (() -> Void)? { get set }
     var onQueueUpdated: (() -> Void)? { get set }
     var onChannelMessage: ((MessageUpdateType) -> Void)? { get set }
-    var onComposeActionUpdated: ((_ index: Int, _ action: ComposeUIAction) -> Void)? { get set }
+    var onComposeActionUpdated: ((_ id: String, _ action: ComposeUIAction) -> Void)? { get set }
 
     init(sessionManager: NINChatSessionManager)
 }
@@ -75,7 +75,7 @@ final class NINChatViewModelImpl: NINChatViewModel {
     var onChannelClosed: (() -> Void)?
     var onErrorOccurred: ((Error) -> Void)?
     var onChannelMessage: ((MessageUpdateType) -> Void)?
-    var onComposeActionUpdated: ((_ index: Int, _ action: ComposeUIAction) -> Void)?
+    var onComposeActionUpdated: ((_ id: String, _ action: ComposeUIAction) -> Void)?
 
     init(sessionManager: NINChatSessionManager) {
         self.sessionManager = sessionManager
@@ -103,8 +103,8 @@ final class NINChatViewModelImpl: NINChatViewModel {
         self.sessionManager.onSessionDeallocated = { [weak self] in
             self?.onChannelMessage?(.clean)
         }
-        self.sessionManager.onComposeActionUpdated = { [weak self] index, action in
-            self?.onComposeActionUpdated?(index, action)
+        self.sessionManager.onComposeActionUpdated = { [weak self] id, action in
+            self?.onComposeActionUpdated?(id, action)
         }
     }
 }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Chat View/ChatView.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Chat View/ChatView.swift
@@ -23,7 +23,7 @@ protocol ChatViewProtocol: UIView {
     func didRemoveMessage(from index: Int)
 
     /** A compose message got updates from the server regarding its options. */
-    func didUpdateComposeAction(at index: Int, with action: ComposeUIAction)
+    func didUpdateComposeAction(_ id: String, with action: ComposeUIAction)
 
     /** Should update table content offset when keyboard state changes. */
     func updateContentSize(_ value: CGFloat)
@@ -60,7 +60,7 @@ final class ChatView: UIView, ChatViewProtocol {
 
     private let videoThumbnailManager = VideoThumbnailManager()
     private var cellConstraints: Array<CGSize> = []
-    private var composeCellActions: [Int:ComposeUIAction] = [:]
+    private var composeCellActions: [String:ComposeUIAction] = [:]
 
     /// To avoid a race condition in updating the chat view
     private let lock = NSLock()
@@ -116,11 +116,11 @@ final class ChatView: UIView, ChatViewProtocol {
         lock.unlock()
     }
 
-    func didUpdateComposeAction(at index: Int, with action: ComposeUIAction) {
+    func didUpdateComposeAction(_ id: String, with action: ComposeUIAction) {
         debugger("Got ui action update for compose for message at: \(index)")
 
-        guard self.composeCellActions[index] == nil else { return }
-        self.composeCellActions[index] = action
+        guard self.composeCellActions[id] == nil else { return }
+        self.composeCellActions[id] = action
     }
 
     func updateContentSize(_ value: CGFloat) {
@@ -191,9 +191,9 @@ extension ChatView {
 
         cell.populateChannel(message: message, configuration: self.sessionManager?.siteConfiguration, imageAssets: self.imageAssets, colorAssets: self.colorAssets, agentAvatarConfig: self.agentAvatarConfig, userAvatarConfig: self.userAvatarConfig, composeState: self.composeMessageStates?[message.messageID])
         if let cell = cell as? ChatChannelComposeCell {
-            if let action = self.composeCellActions[indexPath.row] {
+            if let action = self.composeCellActions[message.messageID] {
                 cell.composeMessageView.updateStates(with: action)
-                composeCellActions.removeValue(forKey: indexPath.row)
+                composeCellActions.removeValue(forKey: message.messageID)
             }
         }
         return cell

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINChatViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINChatViewController.swift
@@ -304,8 +304,8 @@ final class NINChatViewController: UIViewController, ViewController, KeyboardHan
             }
         }
         self.viewModel.loadHistory { _ in }
-        self.viewModel.onComposeActionUpdated = { [weak self] index, action in
-            self?.chatView.didUpdateComposeAction(at: index, with: action)
+        self.viewModel.onComposeActionUpdated = { [weak self] id, action in
+            self?.chatView.didUpdateComposeAction(id, with: action)
         }
     }
     


### PR DESCRIPTION
Using message index, that was done since the first version, resulted in
issues about sending multiple same-type compose messages, which then items
kept the answer from the previous message.

The commit addresses the issue by replacing message index with the
message id, which is unique during a conversation.
