### PR TITLE
override/fix-naming-close-button

### DIFF
--- a/NinchatSDKSwift/Implementations/View/UIKit/Button/CloseButton.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Button/CloseButton.swift
@@ -8,16 +8,16 @@ import UIKit
 
 enum CloseButtonPosition {
     case titlebar
-    case view
-    case conversation
+    case chatTopRight
+    case general
     
     var assetKey: CALayerConstant {
         switch self {
         case .titlebar:
             return .ninchatTitlebarCloseButton
-        case .view:
+        case .chatTopRight:
             return .ninchatChatCloseButton
-        case .conversation:
+        case .general:
             return .ninchatCloseButton
         }
     }
@@ -26,9 +26,9 @@ enum CloseButtonPosition {
         switch self {
         case .titlebar:
             return .ninchatTitlebarCloseEmptyButton
-        case .view:
+        case .chatTopRight:
             return .ninchatChatCloseEmptyButton
-        case .conversation:
+        case .general:
             return .ninchatCloseEmptyButton
         }
     }
@@ -37,9 +37,9 @@ enum CloseButtonPosition {
         switch self {
         case .titlebar:
             return .ninchatColorTitlebarCloseText
-        case .view:
+        case .chatTopRight:
             return .ninchatColorCloseChatText
-        case .conversation:
+        case .general:
             return .ninchatColorCloseText
         }
     }

--- a/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Meta Cell/ChatMetaCell.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Meta Cell/ChatMetaCell.swift
@@ -64,7 +64,7 @@ final class ChatMetaCell: UITableViewCell, ChatMeta, HasCustomLayer {
         if let title = message.closeChatButtonTitle {
             self.deactivate(constraints: [.height])
             self.closeChatButton.buttonTitle = title
-            self.closeChatButton.overrideAssets(with: self.delegate, in: .conversation)
+            self.closeChatButton.overrideAssets(with: self.delegate, in: .general)
             self.closeChatButton.closure = { [weak self] button in
                 self?.onCloseChatTapped?(button)
             }

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINChatViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINChatViewController.swift
@@ -127,7 +127,7 @@ final class NINChatViewController: UIViewController, ViewController, KeyboardHan
 
             let closeTitle = self.sessionManager?.translate(key: Constants.kCloseChatText.rawValue, formatParams: [:])
             closeChatButton.buttonTitle = closeTitle
-            closeChatButton.overrideAssets(with: self.delegate, in: .view)
+            closeChatButton.overrideAssets(with: self.delegate, in: .chatTopRight)
             closeChatButton.closure = { [weak self] button in
                 DispatchQueue.main.async {
                     self?.onCloseChatTapped()

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINQueueViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINQueueViewController.swift
@@ -46,7 +46,7 @@ final class NINQueueViewController: UIViewController, ViewController, HasCustomL
 
             let closeTitle = self.sessionManager?.translate(key: Constants.kCloseChatText.rawValue, formatParams: [:])
             cancelQueueButton.buttonTitle = closeTitle
-            cancelQueueButton.overrideAssets(with: self.delegate, in: .view)
+            cancelQueueButton.overrideAssets(with: self.delegate, in: .general)
             cancelQueueButton.closure = { [weak self] _ in
                 DispatchQueue.main.async {
                     self?.onCancelQueueTapped()
@@ -185,7 +185,7 @@ extension NINQueueViewController {
 
     private func overrideAssets() {
         overrideTitlebarAssets()
-        cancelQueueButton.overrideAssets(with: self.delegate, in: .view)
+        cancelQueueButton.overrideAssets(with: self.delegate, in: .general)
 
         if let spinnerImage = self.delegate?.override(imageAsset: .ninchatIconLoader) {
             self.spinnerImageView.image = spinnerImage


### PR DESCRIPTION
The new naming:
    - using 'ninchatChatCloseButton' for NINChatViewController top right
      corner
    - using 'ninchatTitlebarCloseButton' for titlebar close button
    - using 'ninchatCloseButton' for all other close buttons
