### PR TITLE
Get 'message' from server and send it

### DIFF
--- a/NinchatSDKSwift/Implementations/Extensions/NINLowLevelClientProps+Extension.swift
+++ b/NinchatSDKSwift/Implementations/Extensions/NINLowLevelClientProps+Extension.swift
@@ -248,6 +248,7 @@ protocol NINLowLevelChannelProps {
     var channelAttributes: NINResult<NINLowLevelClientProps> { get }
     var channelClosed: NINResult<Bool> { get }
     var channelSuspended: NINResult<Bool> { get }
+    var channelAudienceMetadata: NINResult<NINLowLevelClientProps> { get }
 
     var channelID: NINResult<String> { set get }
     var channelMemberAttributes: NINResult<NINLowLevelClientProps> { set get }
@@ -280,6 +281,10 @@ extension NINLowLevelClientProps: NINLowLevelChannelProps {
         }
     }
 
+    var channelAudienceMetadata: NINResult<NINLowLevelClientProps> {
+        get { self.get(forKey: "audience_metadata") }
+    }
+
     var channelID: NINResult<String> {
         get { self.get(forKey: "channel_id") }
         set { self.set(value: newValue.value, forKey: "channel_id") }
@@ -300,6 +305,7 @@ protocol NINLowLevelUserProps {
     var info: NINResult<NINLowLevelClientProps> { get }
     var jobTitle: NINResult<String> { get }
     var channels: NINResult<NINLowLevelClientProps> { get }
+    var preAnswers: NINResult<NINLowLevelClientProps> { get }
 
     var userID: NINResult<String> { set get }
     var userAttributes: NINResult<NINLowLevelClientProps> { set get }
@@ -353,6 +359,10 @@ extension NINLowLevelClientProps: NINLowLevelUserProps {
     var userAttributes: NINResult<NINLowLevelClientProps> {
         get { self.get(forKey: "user_attrs") }
         set { self.set(value: newValue.value, forKey: "user_attrs") }
+    }
+
+    var preAnswers: NINResult<NINLowLevelClientProps> {
+        get { self.get(forKey: "pre_answers") }
     }
 }
 

--- a/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSeesionManagerPrivate.swift
+++ b/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSeesionManagerPrivate.swift
@@ -130,7 +130,8 @@ extension NINChatSessionManagerImpl {
     internal func didJoinChannel(param: NINLowLevelClientProps) throws {
         guard currentQueueID != nil else { throw NINSessionExceptions.noActiveQueue }
         if case let .failure(error) = param.channelID { throw error }
-        self.didJoinChannel(channelID: param.channelID.value)
+
+        var message: String? = nil
 
         /// Extract the channel members' data
         if case let .failure(error) = param.channelMembers { throw error }
@@ -151,12 +152,23 @@ extension NINChatSessionManagerImpl {
         } catch {
             debugger(error.localizedDescription)
         }
-        
+
+        if case let .success(metadata) = param.channelAudienceMetadata {
+            if case let .success(answers) = metadata.preAnswers {
+                let parser = NINChatClientPropsParser()
+                try? answers.accept(parser)
+
+                message = parser.properties.first(where: { $0.key == "message" })?.value as? String
+            }
+        }
+
+        try self.didJoinChannel(channelID: param.channelID.value, message: message)
+
         /// Signal channel join event to the asynchronous listener
         self.onChannelJoined?()
     }
 
-    internal func didJoinChannel(channelID: String) {
+    internal func didJoinChannel(channelID: String, message: String?) throws {
         delegate?.log(value: "Joined channel ID: \(channelID)")
 
         /// Set the currently active channel
@@ -183,6 +195,11 @@ extension NINChatSessionManagerImpl {
 
         /// Insert a meta message about the conversation start
         self.add(message: MetaMessage(timestamp: Date(), messageID: self.chatMessages.first?.messageID, text: self.translate(key: "Audience in queue {{queue}} accepted.", formatParams: ["queue": self.describedQueue?.name ?? ""]) ?? "", closeChatButtonTitle: nil))
+
+        /// send message if any
+        if let message = message {
+            try self.send(message: message) { _ in }
+        }
     }
     
     internal func didPartChannel(param: NINLowLevelClientProps) throws {

--- a/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSessionManagerEventHandlers.swift
+++ b/NinchatSDKSwift/Implementations/Managers/Session Manager/NINChatSessionManagerEventHandlers.swift
@@ -87,7 +87,7 @@ extension NINChatSessionManagerImpl: NINChatSessionManagerEventHandlers {
                                     guard error == nil else { self?.onActionSessionEvent?(credentials, eventType, error); return }
                                     guard let channelID = self?.currentChannelID else { debugger("Error in getting current channel id"); return }
 
-                                    self?.didJoinChannel(channelID: channelID)
+                                    try? self?.didJoinChannel(channelID: channelID, message: nil)
                                     self?.onActionSessionEvent?(credentials, eventType, nil)
                                 }
                             } catch {

--- a/NinchatSDKSwift/Implementations/View Model/NINChatViewModel.swift
+++ b/NinchatSDKSwift/Implementations/View Model/NINChatViewModel.swift
@@ -39,7 +39,6 @@ protocol NINChatStateProtocol {
 
 protocol NINChatMessageProtocol {
     var onErrorOccurred: ((Error) -> Void)? { get set }
-    var backlogMessages: String? { get set }
 
     func updateWriting(state: Bool)
     func send(message: String, completion: @escaping (Error?) -> Void)

--- a/NinchatSDKSwift/Implementations/View Model/NINQuestionnaireViewModel.swift
+++ b/NinchatSDKSwift/Implementations/View Model/NINQuestionnaireViewModel.swift
@@ -15,7 +15,6 @@ protocol NINQuestionnaireViewModel {
     var requirementsSatisfied: Bool { get }
     var shouldWaitForNextButton: Bool { get }
     var questionnaireAnswers: NINLowLevelClientProps { get }
-    var backlogMessages: String? { get }
 
     var onErrorOccurred: ((Error) -> Void)? { get set }
     var onQuestionnaireFinished: ((Queue?, _ queueIsClosed: Bool, _ exit: Bool) -> Void)? { get set }
@@ -251,10 +250,6 @@ extension NINQuestionnaireViewModelImpl {
         NINLowLevelClientProps.initiate(metadata: self.answers.filter({ $0.value as? Bool != false }).merging(self.preAnswers) { (current,new) in new })
     }
     
-    var backlogMessages: String? {
-        self.answers.first(where: { $0.key == "message" })?.value as? String
-    }
-
     var requirementsSatisfied: Bool {
         guard self.items.count > self.pageNumber else { return false }
         guard let elements = self.items[self.pageNumber].elements else { return true } /// Return true if the current item is a logic block

--- a/NinchatSDKSwift/Implementations/View Model/NINQueueViewModel.swift
+++ b/NinchatSDKSwift/Implementations/View Model/NINQueueViewModel.swift
@@ -10,8 +10,7 @@ protocol NINQueueViewModel {
     var resumeMode: Bool! { get set }
     var onInfoTextUpdate: ((String?) -> Void)? { get set }
     var onQueueJoin: ((Error?) -> Void)? { get set }
-    var backlogMessages: String? { get }
-    
+
     init(sessionManager: NINChatSessionManager, delegate: NINChatSessionInternalDelegate?)
     func connect(queue: Queue)
     func registerAudience(queue: Queue)
@@ -29,7 +28,6 @@ final class NINQueueViewModelImpl: NINQueueViewModel {
     var onInfoTextUpdate: ((String?) -> Void)?
     var onQueueJoin: ((Error?) -> Void)?
     var resumeMode: Bool!
-    var backlogMessages: String?
 
     init(sessionManager: NINChatSessionManager, delegate: NINChatSessionInternalDelegate?) {
         self.sessionManager = sessionManager

--- a/NinchatSDKSwift/Implementations/View/Coordinator/Coordinator.swift
+++ b/NinchatSDKSwift/Implementations/View/Coordinator/Coordinator.swift
@@ -65,7 +65,7 @@ final class NINCoordinator: NSObject, Coordinator, UIAdaptivePresentationControl
                 if self.hasPreAudienceQuestionnaire {
                     viewController = self.questionnaireViewController(queue: queue, questionnaireType: .pre)
                 } else {
-                    viewController = self.queueViewController(queue: queue, nil)
+                    viewController = self.queueViewController(queue: queue)
                 }
                 self.navigationController?.pushViewController(viewController, animated: true)
             }
@@ -92,7 +92,7 @@ final class NINCoordinator: NSObject, Coordinator, UIAdaptivePresentationControl
         joinViewController.onQueueActionTapped = { [weak self] queue in
             DispatchQueue.main.async {
                 guard let `self` = self else { return }
-                let chatViewController = self.chatViewController(queue: queue, backlogMessage: joinViewController.viewModel.backlogMessages)
+                let chatViewController = self.chatViewController(queue: queue)
                 self.navigationController?.pushViewController(chatViewController, animated: true)
             }
         }
@@ -190,9 +190,9 @@ final class NINCoordinator: NSObject, Coordinator, UIAdaptivePresentationControl
     func start(with queue: String?, resume: ResumeMode?, within navigation: UINavigationController?) -> UIViewController? {
         let topViewController: UIViewController
         if let resume = resume {
-            topViewController = self.queueViewController(resume: resume, queue: nil, nil)
+            topViewController = self.queueViewController(resume: resume, queue: nil)
         } else if let queue = queue, let target = self.sessionManager.queues.filter({ $0.queueID == queue }).first {
-            topViewController = hasPreAudienceQuestionnaire ? self.questionnaireViewController(queue: target, questionnaireType: .pre) : self.queueViewController(queue: target, nil)
+            topViewController = hasPreAudienceQuestionnaire ? self.questionnaireViewController(queue: target, questionnaireType: .pre) : self.queueViewController(queue: target)
         } else {
             topViewController = self.initialViewController
         }
@@ -252,10 +252,10 @@ extension NINCoordinator {
         }
         vc.style = style
         vc.type = questionnaireType
-        vc.completeQuestionnaire = { [weak self] queue, backlogMessage in
+        vc.completeQuestionnaire = { [weak self] queue in
             DispatchQueue.main.async {
                 guard let `self` = self, questionnaireType == .pre else { return }
-                self.navigationController?.pushViewController(self.queueViewController(queue: queue, backlogMessage), animated: true)
+                self.navigationController?.pushViewController(self.queueViewController(queue: queue), animated: true)
             }
         }
         vc.cancelQuestionnaire = { [weak self] in
@@ -277,10 +277,8 @@ extension NINCoordinator {
         return vc
     }
 
-    internal func queueViewController(resume: ResumeMode? = nil, queue: Queue?, _ backlogMessage: String?) -> NINQueueViewController {
+    internal func queueViewController(resume: ResumeMode? = nil, queue: Queue?) -> NINQueueViewController {
         let vm = NINQueueViewModelImpl(sessionManager: self.sessionManager, delegate: self.delegate)
-        vm.backlogMessages = backlogMessage
-        
         let vc = self.queueViewController
         vc.viewModel = vm
         vc.resumeMode = resume
@@ -293,9 +291,8 @@ extension NINCoordinator {
         return vc
     }
 
-    internal func chatViewController(queue: Queue?, backlogMessage: String? = nil) -> NINChatViewController {
+    internal func chatViewController(queue: Queue?) -> NINChatViewController {
         let vc = self.chatViewController
-        vc.viewModel.backlogMessages = backlogMessage
         vc.queue = queue
 
         return vc

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINQuestionnaireViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINQuestionnaireViewController.swift
@@ -89,7 +89,7 @@ final class NINQuestionnaireViewController: UIViewController, ViewController, Ke
             viewModel.onQuestionnaireFinished = { [weak self] queue, queueIsClosed, exit in
                 /// Complete questionnaire and navigate to the queue.
                 if let queue = queue {
-                    self?.completeQuestionnaire?(queue, self?.viewModel.backlogMessages)
+                    self?.completeQuestionnaire?(queue)
                 }
                 /// Finish the session if it is an `exit` element
                 else if exit {
@@ -121,7 +121,7 @@ final class NINQuestionnaireViewController: UIViewController, ViewController, Ke
     }
     var ratingViewModel: NINRatingViewModel?
     var rating: ChatStatus?
-    var completeQuestionnaire: ((_ queue: Queue, _ backlogMessage: String?) -> Void)?
+    var completeQuestionnaire: ((_ queue: Queue) -> Void)?
     var cancelQuestionnaire: (() -> Void)?
     
     // MARK: - SubViews


### PR DESCRIPTION
see https://github.com/somia/mobile/issues/371#issuecomment-989826738

The PR fetches `message` from server instead of passing it through different states. It was tested against different resumption scenarios, and works fine.