### PR TITLE
Fix overriding agent and user avatars

### DIFF
--- a/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Channel Cell/ChatChannelCell.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Channel Cell/ChatChannelCell.swift
@@ -87,7 +87,7 @@ class ChatChannelCell: UITableViewCell, ChatCell, ChannelCell {
         imageView.isHidden = !(config?.show ?? false)
         if let overrideURL = config?.imageOverrideURL {
             imageView.image(from: overrideURL, defaultImage: override)
-        } else if let url = url {
+        } else if let url = url, !url.isEmpty {
             imageView.image(from: url, defaultImage: override)
         } else {
             imageView.image = override

--- a/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Typing Cell/ChatTypingCell.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Chat View/Chat Cells/Typing Cell/ChatTypingCell.swift
@@ -68,7 +68,7 @@ class ChatTypingCell: UITableViewCell {
         
         if let overrideURL = config?.imageOverrideURL {
             imageView.image(from: overrideURL, defaultImage: override)
-        } else if let url = url {
+        } else if let url = url, !url.isEmpty {
             imageView.image(from: url, defaultImage: override)
         } else {
             imageView.image = override


### PR DESCRIPTION
The problem was that when the `message.icon.url` is empty, it is not checked and as the result, the avatar is not set.