### PR TITLE
Show/Skip rating page according to the configuration

### DIFF
--- a/NinchatSDKSwift/Implementations/Models/SiteConfiguration.swift
+++ b/NinchatSDKSwift/Implementations/Models/SiteConfiguration.swift
@@ -25,6 +25,7 @@ protocol SiteConfiguration  {
     var confirmDialogTitle: String? { get }
     var audienceRealm: String? { get }
     var audienceQueues: [String]? { get }
+    var audienceRating: Bool { get }
     func translation(for key: String) -> String?
     var agentAvatar: AnyHashable? { get }
     var agentName: String? { get }
@@ -93,6 +94,9 @@ struct SiteConfigurationImpl: SiteConfiguration {
     }
     var audienceQueues: [String]? {
         self.value(for: "audienceQueues")
+    }
+    var audienceRating: Bool {
+        self.value(for: "audienceRating") ?? false
     }
     func translation(for key: String) -> String? {
         for env in self.prepareEnvironments() {

--- a/NinchatSDKSwift/Implementations/View/Coordinator/Coordinator.swift
+++ b/NinchatSDKSwift/Implementations/View/Coordinator/Coordinator.swift
@@ -137,10 +137,13 @@ final class NINCoordinator: NSObject, Coordinator, UIAdaptivePresentationControl
 
                 /// skip rating page if ´audienceRating = False´
                 /// according to `https://github.com/somia/mobile/issues/380`
-                if self.sessionManager.siteConfiguration.audienceRating == false {
-                    self.delegate?.onDidEnd(); return
+                if self.sessionManager.siteConfiguration.audienceRating {
+                    self.navigationController?.pushViewController(self.ratingViewController, animated: true)
+                } else if self.hasPostAudienceQuestionnaire {
+                    self.navigationController?.pushViewController(self.questionnaireViewController(ratingViewModel: nil, rating: nil, questionnaireType: .post), animated: true)
+                } else {
+                    self.delegate?.onDidEnd()
                 }
-                self.navigationController?.pushViewController(self.ratingViewController, animated: true)
             }
         }
 

--- a/NinchatSDKSwift/Implementations/View/Coordinator/Coordinator.swift
+++ b/NinchatSDKSwift/Implementations/View/Coordinator/Coordinator.swift
@@ -134,6 +134,12 @@ final class NINCoordinator: NSObject, Coordinator, UIAdaptivePresentationControl
         chatViewController.onChatClosed = { [weak self] in
             DispatchQueue.main.async {
                 guard let `self` = self else { return }
+
+                /// skip rating page if ´audienceRating = False´
+                /// according to `https://github.com/somia/mobile/issues/380`
+                if self.sessionManager.siteConfiguration.audienceRating == false {
+                    self.delegate?.onDidEnd(); return
+                }
                 self.navigationController?.pushViewController(self.ratingViewController, animated: true)
             }
         }


### PR DESCRIPTION
closes somia/mobile#380

P.S: If `audienceRating: false`, then the session is closed and the `postAudienceQuestionnaire` is skipped automatically.