### PR TITLE
Reload history when the app returns to the foreground

### DIFF
--- a/NinchatSDKSwift/Implementations/View Model/NINChatViewModel.swift
+++ b/NinchatSDKSwift/Implementations/View Model/NINChatViewModel.swift
@@ -218,7 +218,7 @@ extension NINChatViewModelImpl {
 extension NINChatViewModelImpl {
     func willEnterBackground() {
         debugger("background mode, hangup the video call (if there are any)")
-        /// instead of droping the connection when the app goes to the background
+        /// instead of dropping the connection when the app goes to the background
         /// it is better to stop video stream and let the connection be alive
         /// discussed on `https://github.com/somia/mobile/issues/295`
         self.disableVideoStream(disable: true)
@@ -227,6 +227,26 @@ extension NINChatViewModelImpl {
     func didEnterForeground() {
         /// take the video stream back
         self.disableVideoStream(disable: false)
+
+        /// reload history if the app was in the background
+        ///
+        /// this is a workaround to avoid missing messages
+        /// when the app is in the background, and the OS decides
+        /// to close the connection, or if the user gets suspended
+        /// and not deleted.
+        ///
+        /// if the user was deleted when the app gets back in the
+        /// foreground, the solution we have developed for the issue
+        /// `https://github.com/somia/mobile/issues/368`
+        /// is followed
+        ///
+        /// however, if there is still problems in case the user
+        /// was deleted when the app gets back in foreground (such
+        /// as race conditions in loading history or checking the
+        /// user's status), and if the new issue is critical to resolve,
+        /// then a dedicated task must be opened to investigate the
+        /// problem.
+        self.loadHistory()
     }
 }
 

--- a/NinchatSDKSwift/Implementations/View Model/NINChatViewModel.swift
+++ b/NinchatSDKSwift/Implementations/View Model/NINChatViewModel.swift
@@ -45,7 +45,7 @@ protocol NINChatMessageProtocol {
     func send(action: ComposeContentViewProtocol, completion: @escaping (Error?) -> Void)
     func send(attachment: String, data: Data, completion: @escaping (Error?) -> Void)
     func send(type: MessageType, payload: [String:String], completion: @escaping (Error?) -> Void)
-    func loadHistory(completion: @escaping (Error?) -> Void)
+    func loadHistory()
 }
 
 protocol NINChatPermissionsProtocol {
@@ -282,12 +282,8 @@ extension NINChatViewModelImpl {
         try? self.sessionManager.update(isWriting: state) { _ in  }
     }
 
-    func loadHistory(completion: @escaping (Error?) -> Void) {
-        do {
-            try self.sessionManager.loadHistory(completion: completion)
-        } catch {
-            completion(error)
-        }
+    func loadHistory() {
+        try? self.sessionManager.loadHistory() { _ in }
     }
 }
 

--- a/NinchatSDKSwift/Implementations/View/ViewController/NINChatViewController.swift
+++ b/NinchatSDKSwift/Implementations/View/ViewController/NINChatViewController.swift
@@ -301,10 +301,11 @@ final class NINChatViewController: UIViewController, ViewController, KeyboardHan
                 self?.chatView.tableView.reloadData()
             }
         }
-        self.viewModel.loadHistory { _ in }
         self.viewModel.onComposeActionUpdated = { [weak self] id, action in
             self?.chatView.didUpdateComposeAction(id, with: action)
         }
+
+        self.viewModel.loadHistory()
     }
     
     // MARK: - Helpers


### PR DESCRIPTION
As a workaround for somia/mobile#374, the SDK now reloads the history everytime the app returns to the foreground. **The important point is that, if the guest user is deleted while the app was in the background, we have no options to load the history. This has been discussed and resolved on somia/mobile#368**