### PR TITLE
Fix overwriting layers

### DIFF
--- a/NinchatSDKSwift/Implementations/Extensions/CALayer+Extension.swift
+++ b/NinchatSDKSwift/Implementations/Extensions/CALayer+Extension.swift
@@ -7,10 +7,16 @@
 import UIKit
 
 extension CALayer {
-    func apply(_ layer: CALayer) {
+    func apply(_ layer: CALayer, force: Bool = true) {
         var count = UInt32()
         guard let layerClassProps: UnsafeMutablePointer <objc_property_t> = class_copyPropertyList(CALayer.self, &count) else {
             fatalError("unable to fetch class properties")
+        }
+        
+        if self.name == LAYER_NAME, !force {
+            /// the layer was set before, skip overwriting it
+            /// unless it is forced (e.g. button selected)
+            return
         }
         
         (0..<count)

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Cells/QuestionnaireCell.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Cells/QuestionnaireCell.swift
@@ -64,6 +64,7 @@ class QuestionnaireCell: UITableViewCell {
         
         conversationTitleContainerView.isHidden = false
         conversationViewContentView.isHidden = false
+        conversationContentViewStyle.isHidden = false
     }
 
     func addElement(_ element: QuestionnaireElement) {
@@ -111,11 +112,10 @@ class QuestionnaireCell: UITableViewCell {
         }
         
         if let layer = delegate.override(layerAsset: .ninchatBubbleQuestionnaire) {
-            conversationTitleContainerView.layer.apply(layer)
+            conversationTitleContainerView.layer.apply(layer, force: false)
             conversationContentViewStyle.isHidden = true
         } else if let backgroundColor = delegate.override(questionnaireAsset: .ninchatQuestionnaireColorBubble) {
             conversationContentViewStyle.tintColor = backgroundColor
-            conversationContentViewStyle.isHidden = false
         }
     }
 


### PR DESCRIPTION
Overwriting a layer can result in unexpected behaviour, such as being
hidden on scrolling. This commit fixes the issue, but let componenets
decide if they'd like to forcely overwrite it. This is useful for
interactive componenets such as QuestionnaireRadio  elements.
