### PR TITLE
fit embedded image for a text questionnaire

### DIFF
--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementText.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementText.swift
@@ -80,13 +80,17 @@ final class QuestionnaireElementText: UITextView, QuestionnaireElement, HasTitle
         self.textContainerInset = UIEdgeInsets(top: topInset, left: 0.0, bottom: bottomInset, right: 0.0)
         self.textContainer.lineFragmentPadding = 0
     }
+    
+    fileprivate func estimatedWidth() -> CGFloat {
+        (UIApplication.topViewController()?.view.bounds ?? UIScreen.main.bounds).width - conversationStylePadding
+    }
 }
 
 extension QuestionnaireElement where Self:QuestionnaireElementText {
     func shapeView(_ configuration: QuestionnaireConfiguration?) {
         self.textAlignment = .left
         self.backgroundColor = .clear
-        self.setAttributed(text: configuration?.label ?? "", font: .ninchat)
+        self.setAttributed(text: configuration?.label ?? "", font: .ninchat, width: self.estimatedWidth())
         self.elementConfiguration = configuration
     }
 }


### PR DESCRIPTION
The width is used to fit the embedded image to the size of the cell. It was removed in the previous commits wrongly

see somia/mobile#388
