### PR TITLE
Add default and override background options for all questionnaire elements

### DIFF
--- a/NinchatSDKSwift/Implementations/Constants.swift
+++ b/NinchatSDKSwift/Implementations/Constants.swift
@@ -117,6 +117,7 @@ public enum QuestionnaireColorConstants {
     case ninchatQuestionnaireColorTextInput
     case ninchatQuestionnaireColorRadioSelectedText
     case ninchatQuestionnaireColorRadioUnselectedText
+    case ninchatQuestionnaireColorCheckboxBackground
     case ninchatQuestionnaireColorCheckboxSelectedText
     case ninchatQuestionnaireCheckboxSelectedIndicator
     case ninchatQuestionnaireColorCheckboxUnselectedText
@@ -128,6 +129,7 @@ public enum QuestionnaireColorConstants {
     case ninchatQuestionnaireColorNavigationNextText
     case ninchatQuestionnaireColorNavigationBackText
     case ninchatQuestionnaireColorBubble
+    case ninchatQuestionnaireColorTextInputBackground
     case ninchatQuestionnaireColorTextInputBorder
     case ninchatQuestionnaireColorTextInputErrorBorder
     case ninchatQuestionnaireColorSelectBorder

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementCheckbox.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementCheckbox.swift
@@ -72,7 +72,6 @@ final class QuestionnaireElementCheckbox: UIView, QuestionnaireElement, Question
             }
         })
         self.view.allSubviews.filter({ $0.tag >= 200 }).compactMap({ $0 as? UIImageView }).forEach({ imageView in
-            
             if let tintColor = delegate?.override(questionnaireAsset: .ninchatQuestionnaireCheckboxSelectedIndicator) {
                 imageView.tint = tintColor
             } else {
@@ -87,6 +86,7 @@ final class QuestionnaireElementCheckbox: UIView, QuestionnaireElement, Question
                 view.round(radius: 23.0 / 2, borderWidth: 2.0, borderColor: self.iconBorderNormalColor)
             }
         })
+        self.view.backgroundColor = delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorCheckboxBackground) ?? .white
     }
 
     // MARK: - QuestionnaireSettable

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextArea.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextArea.swift
@@ -42,6 +42,7 @@ final class QuestionnaireElementTextArea: UIView, QuestionnaireElementWithTitle,
         if let borderColor = delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorTextInputErrorBorder) {
             errorBorderColor = borderColor
         }
+        self.view.backgroundColor = delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorTextInputBackground) ?? .white
         self.updateBorder()
     }
 

--- a/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextField.swift
+++ b/NinchatSDKSwift/Implementations/View/UIKit/Questionnaire View/Elements/QuestionnaireElementTextField.swift
@@ -42,6 +42,7 @@ final class QuestionnaireElementTextField: UIView, QuestionnaireElementWithTitle
         if let borderColor = delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorTextInputErrorBorder) {
             errorBorderColor = borderColor
         }
+        self.view.backgroundColor = delegate?.override(questionnaireAsset: .ninchatQuestionnaireColorTextInputBackground) ?? .white
         self.updateBorder()
     }
 


### PR DESCRIPTION
The PR adds new keys for default backgrounds:

- `ninchatQuestionnaireColorCheckboxBackground`
- `ninchatQuestionnaireColorTextInputBackground`

as a part of somia/mobile#388