### PR TITLE
Jitsi WebRTC instead of whole Jitsi

### DIFF
--- a/NinchatSDKSwift.podspec
+++ b/NinchatSDKSwift.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "NinchatSDKSwift"
-  s.version      = "0.6.0"
+  s.version      = "0.6.1"
   s.summary      = "iOS SDK for Ninchat, Swift version"
   s.description  = "For building iOS applications using Ninchat messaging."
   s.homepage     = "https://ninchat.com/"
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
   }
 
   # Cocoapods dependencies
-  s.dependency "JitsiMeetSDK", "7.0.0"
+  s.dependency "JitsiWebRTC", "106.0.0"
   s.dependency 'AnyCodable-FlightSchool', '~> 0.2.3'
   s.dependency "AutoLayoutSwift", "4.0.0"
   s.dependency "NinchatLowLevelClient", "~> 0.6.0"

--- a/Podfile
+++ b/Podfile
@@ -9,7 +9,7 @@ def libraries
   pod 'AnyCodable-FlightSchool', '~> 0.2.3'
   pod 'AutoLayoutSwift', '4.0.0'
   pod 'NinchatLowLevelClient', '~> 0.6.0'
-  pod 'JitsiMeetSDK', '7.0.0'
+  pod 'JitsiWebRTC', '106.0.0'
 end
 
 target 'NinchatSDKSwift' do


### PR DESCRIPTION
decided to keep only Jitsi WebRTC dependency for now, 
to avoid ReactNative confilcts with RN projects that use Ninchat SDK, 
until a proper solution is found to solve it